### PR TITLE
Add message printing capability

### DIFF
--- a/nexus_capabilities/CMakeLists.txt
+++ b/nexus_capabilities/CMakeLists.txt
@@ -123,6 +123,7 @@ add_library(nexus_builtin_capabilities SHARED
   src/capabilities/execute_trajectory.cpp
   src/capabilities/gripper_capability.cpp
   src/capabilities/gripper_control.cpp
+  src/capabilities/log_message_capability.cpp
   src/capabilities/plan_motion_capability.cpp
   src/capabilities/plan_motion.cpp
 )

--- a/nexus_capabilities/src/capabilities/log_message_capability.cpp
+++ b/nexus_capabilities/src/capabilities/log_message_capability.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2023 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "log_message_capability.hpp"
+#include <geometry_msgs/msg/pose.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/transform.hpp>
+#include <geometry_msgs/msg/transform_stamped.hpp>
+
+namespace nexus::capabilities {
+
+using rcl_interfaces::msg::ParameterDescriptor;
+
+void LogMessageCapability::configure(
+  rclcpp_lifecycle::LifecycleNode::SharedPtr node,
+  std::shared_ptr<const ContextManager> /* ctx_mgr */,
+  BT::BehaviorTreeFactory& bt_factory)
+{
+  bt_factory.registerSimpleAction("log_message",
+    [this, w_node = std::weak_ptr{node}](BT::TreeNode& bt)
+    {
+      auto node = w_node.lock();
+      if (!node)
+      {
+        std::cerr << "FATAL ERROR!!! NODE IS DESTROYED WHILE THERE ARE STILL REFERENCES!!!" << std::endl;
+        std::terminate();
+      }
+      return print_str(bt, *node);
+    },
+    {BT::InputPort<std::string>("msg")}
+  );
+
+  bt_factory.registerSimpleAction("log_message.Pose",
+    [this, w_node = std::weak_ptr{node}](BT::TreeNode& bt)
+    {
+      auto node = w_node.lock();
+      if (!node)
+      {
+        std::cerr << "FATAL ERROR!!! NODE IS DESTROYED WHILE THERE ARE STILL REFERENCES!!!" << std::endl;
+        std::terminate();
+      }
+      return print_msg<geometry_msgs::msg::Pose>(bt, *node);
+    },
+    {BT::InputPort<geometry_msgs::msg::Pose>("msg")}
+  );
+
+  bt_factory.registerSimpleAction("log_message.PoseStamped",
+    [this, w_node = std::weak_ptr{node}](BT::TreeNode& bt)
+    {
+      auto node = w_node.lock();
+      if (!node)
+      {
+        std::cerr << "FATAL ERROR!!! NODE IS DESTROYED WHILE THERE ARE STILL REFERENCES!!!" << std::endl;
+        std::terminate();
+      }
+      return print_msg<geometry_msgs::msg::PoseStamped>(bt, *node);
+    },
+    {BT::InputPort<geometry_msgs::msg::PoseStamped>("msg")}
+  );
+
+  bt_factory.registerSimpleAction("log_message.Transform",
+    [this, w_node = std::weak_ptr{node}](BT::TreeNode& bt)
+    {
+      auto node = w_node.lock();
+      if (!node)
+      {
+        std::cerr << "FATAL ERROR!!! NODE IS DESTROYED WHILE THERE ARE STILL REFERENCES!!!" << std::endl;
+        std::terminate();
+      }
+      return print_msg<geometry_msgs::msg::Transform>(bt, *node);
+    },
+    {BT::InputPort<geometry_msgs::msg::Transform>("msg")}
+  );
+
+  bt_factory.registerSimpleAction("log_message.TransformStamped",
+    [this, w_node = std::weak_ptr{node}](BT::TreeNode& bt)
+    {
+      auto node = w_node.lock();
+      if (!node)
+      {
+        std::cerr << "FATAL ERROR!!! NODE IS DESTROYED WHILE THERE ARE STILL REFERENCES!!!" << std::endl;
+        std::terminate();
+      }
+      return print_msg<geometry_msgs::msg::TransformStamped>(bt, *node);
+    },
+    {BT::InputPort<geometry_msgs::msg::TransformStamped>("msg")}
+  );
+}
+
+}
+
+#include <pluginlib/class_list_macros.hpp>
+
+PLUGINLIB_EXPORT_CLASS(
+  nexus::capabilities::LogMessageCapability,
+  nexus::Capability
+)

--- a/nexus_capabilities/src/capabilities/log_message_capability.hpp
+++ b/nexus_capabilities/src/capabilities/log_message_capability.hpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2023 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef NEXUS_CAPABILITIES__CAPABILITIES__LOG_MESSAGE_CAPABILITY_HPP
+#define NEXUS_CAPABILITIES__CAPABILITIES__LOG_MESSAGE_CAPABILITY_HPP
+
+#include <nexus_capabilities/capability.hpp>
+#include <nexus_capabilities/context_manager.hpp>
+#include <nexus_endpoints.hpp>
+
+#include <behaviortree_cpp_v3/bt_factory.h>
+
+#include <rclcpp_action/rclcpp_action.hpp>
+#include <rclcpp_lifecycle/lifecycle_node.hpp>
+
+#include <memory>
+#include <string>
+
+namespace nexus::capabilities {
+
+/**
+ * Capability to log messages to stdout.
+ */
+class LogMessageCapability : public Capability
+{
+  /**
+   * @copydoc Capability::declare_params
+   */
+public: void declare_params(rclcpp_lifecycle::LifecycleNode& /* node */) final {}
+
+  /**
+   * @copydoc Capability::configure
+   */
+public: void configure(rclcpp_lifecycle::LifecycleNode::SharedPtr node,
+    std::shared_ptr<const ContextManager> ctx_mgr,
+    BT::BehaviorTreeFactory& bt_factory) final;
+
+  /**
+   * @copydoc Capability::activate
+   */
+public: void activate() final {}
+
+  /**
+   * @copydoc Capability::deactivate
+   */
+public: void deactivate() final {}
+
+private:
+  template<typename MsgT, typename NodeT>
+  BT::NodeStatus print_msg(BT::TreeNode& bt, NodeT& node)
+  {
+    auto msg = bt.getInput<MsgT>("msg");
+    if (!msg)
+    {
+      RCLCPP_ERROR_STREAM(
+        node.get_logger(), "log_message must be given a `msg` to print!"
+      );
+      return BT::NodeStatus::FAILURE;
+    }
+    RCLCPP_INFO_STREAM(node.get_logger(), "PRINTING MSG:\n===\n" << to_yaml(*msg) << "===");
+    return BT::NodeStatus::SUCCESS;
+  }
+
+  template<typename NodeT>
+  BT::NodeStatus print_str(BT::TreeNode& bt, NodeT& node)
+  {
+    auto msg = bt.getInput<std::string>("msg");
+    if (!msg)
+    {
+      RCLCPP_ERROR_STREAM(
+        node.get_logger(), "log_message must be given a `msg` to print!"
+      );
+      return BT::NodeStatus::FAILURE;
+    }
+    RCLCPP_INFO_STREAM(node.get_logger(), "PRINTING MSG:\n===\n" << *msg << "===");
+    return BT::NodeStatus::SUCCESS;
+  }
+};
+
+}
+
+#endif

--- a/nexus_capabilities/src/capabilities/plugins.xml
+++ b/nexus_capabilities/src/capabilities/plugins.xml
@@ -15,6 +15,10 @@
     <description>Gripper capability.</description>
   </class>
 
+  <class type="nexus::capabilities::LogMessageCapability" base_class_type="nexus::Capability">
+    <description>LogMessage capability.</description>
+  </class>
+
   <class type="nexus::capabilities::PlanMotionCapability" base_class_type="nexus::Capability">
     <description>PlanMotion capability.</description>
   </class>


### PR DESCRIPTION
This PR adds a capability that can print the following message types (and also a raw string):
- `geometry_msgs::msg::Pose`
- `geometry_msgs::msg::PoseStamped`
- `geometry_msgs::msg::Transform`
- `geometry_msgs::msg::TransformStamped`

It goes a long way in helping to introspect the content of messages flying around the behavior tree.