### PR TITLE
Fix moveit_msgs version for humble

### DIFF
--- a/thirdparty.repos
+++ b/thirdparty.repos
@@ -2,7 +2,7 @@ repositories:
   thirdparty/moveit/moveit_msgs:
     type: git
     url: https://github.com/ros-planning/moveit_msgs.git
-    version: 2.2.1
+    version: 2.2.2
   thirdparty/moveit/moveit2:
     type: git
     url: https://github.com/koonpeng/moveit2.git


### PR DESCRIPTION
Fix #5 

Setting the moveit_msgs version to `2.2.1` which is the latest on `humble`. https://github.com/ros/rosdistro/blob/1778246d21399eaf2e78b7b147eb60f07c8728f5/humble/distribution.yaml#L3362

In the near future we will be switching to `iron` and will not need to clone and build any moveit pkgs from source. We're doing this presently as the fixes in moveit that we submitted are not backported to `humble`. 