### PR TITLE
Bump moveit_msgs

### DIFF
--- a/thirdparty.repos
+++ b/thirdparty.repos
@@ -2,7 +2,7 @@ repositories:
   thirdparty/moveit/moveit_msgs:
     type: git
     url: https://github.com/ros-planning/moveit_msgs.git
-    version: 2.2.2
+    version: 2.3.0
   thirdparty/moveit/moveit2:
     type: git
     url: https://github.com/ros-planning/moveit2.git


### PR DESCRIPTION
This is needed for https://github.com/ros-planning/moveit2/commit/cdf7a98689b1400c343417a7f7d35089287a0dfd which has been included on the `iron` branch.