### PR TITLE
Implement motion plan cache

### DIFF
--- a/.github/workflows/nexus_integration_tests.yaml
+++ b/.github/workflows/nexus_integration_tests.yaml
@@ -40,6 +40,8 @@ jobs:
         rosdep update
         rosdep install --from-paths . -yir
     - name: build
-      run: /ros_entrypoint.sh colcon build --packages-up-to nexus_integration_tests --mixin release lld --cmake-args -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-    - name: test
+      run: /ros_entrypoint.sh colcon build --packages-up-to nexus_integration_tests nexus_motion_planner --mixin release lld --cmake-args -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+    - name: Test - Unit Tests
+      run: . ./install/setup.bash && RMW_IMPLEMENTATION=rmw_cyclonedds_cpp /ros_entrypoint.sh colcon test --packages-select nexus_motion_planner --event-handlers=console_direct+
+    - name: Test - Integration Test
       run: . ./install/setup.bash && cd nexus_integration_tests && RMW_IMPLEMENTATION=rmw_cyclonedds_cpp /ros_entrypoint.sh python3 -m unittest

--- a/nexus_capabilities/src/capabilities/plan_motion.cpp
+++ b/nexus_capabilities/src/capabilities/plan_motion.cpp
@@ -120,6 +120,17 @@ make_request()
   req->max_velocity_scaling_factor = scale_speed;
   req->max_acceleration_scaling_factor = scale_speed;
 
+  auto maybe_read_only =
+    this->getInput<bool>("force_cache_mode_execute_read_only");
+  if (maybe_read_only.has_value())
+  {
+    req->force_cache_mode_execute_read_only = maybe_read_only.value();
+  }
+  else
+  {
+    req->force_cache_mode_execute_read_only = false;
+  }
+
   RCLCPP_DEBUG_STREAM(this->_logger,
     "planning to " << req->goal_pose.pose << " at frame " <<
       req->goal_pose.header.frame_id << " with cartesian " << req->cartesian << "and scaled speed of " <<

--- a/nexus_capabilities/src/capabilities/plan_motion.hpp
+++ b/nexus_capabilities/src/capabilities/plan_motion.hpp
@@ -66,6 +66,9 @@ public: static BT::PortsList providedPorts()
       BT::InputPort<std::vector<moveit_msgs::msg::JointConstraint>>(
         "start_constraints",
         "OPTIONAL. If provided the the joint_constraints are used as the start condition. Else, the current state of the robot will be used as the start."),
+      BT::InputPort<bool>(
+        "force_cache_mode_execute_read_only",
+        "OPTIONAL. Set true to force cache mode to ExecuteReadOnly for this request."),
       BT::OutputPort<moveit_msgs::msg::RobotTrajectory>(
         "result", "The resulting trajectory.")};
   }

--- a/nexus_motion_planner/CMakeLists.txt
+++ b/nexus_motion_planner/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(trajectory_msgs REQUIRED)
 find_package(warehouse_ros REQUIRED)
+find_package(warehouse_ros_sqlite REQUIRED)
 
 include_directories(include)
 
@@ -28,6 +29,7 @@ set (motion_planner_server_dependencies
   rclcpp_action
   rclcpp_lifecycle
   warehouse_ros
+  warehouse_ros_sqlite
   tf2
   tf2_ros
 )
@@ -45,7 +47,7 @@ set(LIBRARY_NAME motion_planner_server_core)
 set(EXECUTABLE_NAME motion_planner_server)
 
 # Server executable
-add_executable(${EXECUTABLE_NAME} src/main.cpp src/motion_planner_server.cpp)
+add_executable(${EXECUTABLE_NAME} src/main.cpp src/motion_planner_server.cpp src/motion_plan_cache.cpp)
 ament_target_dependencies(${EXECUTABLE_NAME} ${motion_planner_server_dependencies})
 
 # Test executable

--- a/nexus_motion_planner/CMakeLists.txt
+++ b/nexus_motion_planner/CMakeLists.txt
@@ -105,11 +105,17 @@ if(BUILD_TESTING)
    WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
   )
 
-  # TODO(YV): Fix these tests.
-  # add_launch_test(
-  #   test/test_request.test.py
-  #   TIMEOUT 60
-  # )
+  # Motion planner server test with cache mode unset
+  add_launch_test(
+    test/test_request.test.py
+    TIMEOUT 60
+  )
+
+  # Motion planner server test with cache mode set (so it uses the cache)
+  add_launch_test(
+    test/test_request_with_cache.test.py
+    TIMEOUT 60
+  )
 endif()
 
 ament_export_dependencies(${motion_planner_server_dependencies} ${motion_plan_cache_dependencies})

--- a/nexus_motion_planner/CMakeLists.txt
+++ b/nexus_motion_planner/CMakeLists.txt
@@ -28,10 +28,15 @@ set (motion_planner_server_dependencies
   rclcpp
   rclcpp_action
   rclcpp_lifecycle
-  warehouse_ros
-  warehouse_ros_sqlite
   tf2
   tf2_ros
+)
+
+set (motion_plan_cache_dependencies
+  moveit_ros_planning_interface
+  rclcpp
+  warehouse_ros
+  warehouse_ros_sqlite
 )
 
 set (test_request_dependencies
@@ -43,12 +48,17 @@ set (test_request_dependencies
 )
 
 #===============================================================================
-set(LIBRARY_NAME motion_planner_server_core)
+set(MOTION_PLAN_CACHE_LIBRARY_NAME motion_planner_server_core)
 set(EXECUTABLE_NAME motion_planner_server)
 
+# Motion plan cache library
+add_library(${MOTION_PLAN_CACHE_LIBRARY_NAME} src/motion_plan_cache.cpp)
+ament_target_dependencies(${MOTION_PLAN_CACHE_LIBRARY_NAME} ${motion_plan_cache_dependencies})
+
 # Server executable
-add_executable(${EXECUTABLE_NAME} src/main.cpp src/motion_planner_server.cpp src/motion_plan_cache.cpp)
+add_executable(${EXECUTABLE_NAME} src/main.cpp src/motion_planner_server.cpp)
 ament_target_dependencies(${EXECUTABLE_NAME} ${motion_planner_server_dependencies})
+target_link_libraries(${EXECUTABLE_NAME} ${MOTION_PLAN_CACHE_LIBRARY_NAME})
 
 # Test executable
 add_executable(test_request src/test_request.cpp)
@@ -67,6 +77,7 @@ install(
 )
 
 if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
   find_package(ament_cmake_uncrustify REQUIRED)
   find_package(launch_testing_ament_cmake REQUIRED)
   find_package(rmf_utils REQUIRED)
@@ -75,11 +86,23 @@ if(BUILD_TESTING)
     NAMES "rmf_code_style.cfg"
     PATHS "${rmf_utils_DIR}/../../../../share/rmf_utils/")
 
+  add_executable(test_motion_plan_cache src/test_motion_plan_cache.cpp)
+  target_link_libraries(test_motion_plan_cache ${MOTION_PLAN_CACHE_LIBRARY_NAME})
+
+  install(TARGETS
+      test_motion_plan_cache
+    RUNTIME DESTINATION lib/${PROJECT_NAME}
+  )
+
   ament_uncrustify(
     ARGN include src test
     CONFIG_FILE ${uncrustify_config_file}
     MAX_LINE_LENGTH 80
     LANGUAGE CPP
+  )
+
+  ament_add_pytest_test(test_motion_plan_cache_py "test/test_motion_plan_cache.py"
+   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
   )
 
   # TODO(YV): Fix these tests.
@@ -89,5 +112,5 @@ if(BUILD_TESTING)
   # )
 endif()
 
-ament_export_dependencies(${motion_planner_server_dependencies})
+ament_export_dependencies(${motion_planner_server_dependencies} ${motion_plan_cache_dependencies})
 ament_package()

--- a/nexus_motion_planner/config/planner_params.yaml
+++ b/nexus_motion_planner/config/planner_params.yaml
@@ -42,17 +42,3 @@ motion_planner_server:
     workspace_max_z: 1.0
     # The seconds within which the current robot state should be valid.
     get_state_wait_seconds: 0.01
-    # Namespaced parameters for each robot when use_namespace is true.
-    # Is important to ensure move_group, robot_state_publisher and
-    # joint_state broadcaster all have the same namespace.
-    # Note: If use_namespace is false, pass these parameters directly.
-    abb_irb1300:
-      robot_description: ""
-      robot_description_semantic: ""
-      group_name: "manipulator"
-      # Group specific kinematic properties.
-      manipulator:
-        kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
-        kinematics_solver_search_resolution: 0.005
-        kinematics_solver_timeout: 0.005
-        kinematics_solver_attempts: 3

--- a/nexus_motion_planner/config/planner_params_with_cache.yaml
+++ b/nexus_motion_planner/config/planner_params_with_cache.yaml
@@ -1,0 +1,76 @@
+motion_planner_server:
+  ros__parameters:
+    # List of robots to generate motion plans for
+    manipulators: ["abb_irb1300"]
+    # The default moveit group for each manipulator
+    default_group_name: "manipulator"
+    # Seconds to wait to connect to an action or service server
+    timeout_duration: 5
+    # Configure the planner_server to query motion plans directly from a move_group
+    # node that is running by initializing a move_group_interface.
+    # When set to false, the planner_server will initialize planning pipelines
+    # to directly compute plans but this has not been implemented yet.
+    use_move_group_interfaces: true
+    # When planning for multiple robots, set this to true.
+    use_namespace: false
+    # Tolerance for goal position.
+    goal_tolerance: 0.005
+    # Maximum seconds to generate a plan.
+    planning_time: 1.0
+    # Maximum number of replanning attempts
+    replan_attempts: 10
+    # If true, the cartesian interpolator will check for collisions.
+    collision_aware_cartesian_path: false
+    # The value of the max_step parameter used in cartesian interpolation.
+    cartesian_max_step: 0.001
+    # The value of the jump_threshold parameter used in cartesian interpolation.
+    cartesian_jump_threshold: 0.0
+    # Set true if trajectory should be executed after a plan is generated.
+    # The execution is a blocking event.
+    execute_trajectory: false
+    # The min_x of workspace bounding box.
+    workspace_min_x: -1.0
+    # The min_y of workspace bounding box.
+    workspace_min_y: -1.0
+    # The min_z of workspace bounding box.
+    workspace_min_z: -1.0
+    # The max_x of workspace bounding box.
+    workspace_max_x: 1.0
+    # The max_y of workspace bounding box.
+    workspace_max_y: 1.0
+      # The max_z of workspace bounding box.
+    workspace_max_z: 1.0
+    # The seconds within which the current robot state should be valid.
+    get_state_wait_seconds: 0.01
+
+    ## Motion Plan Cache Parameters
+    # Planner database mode. Valid values:
+    #   - Unset: Always plan. No caching.
+    #   - TrainingOverwrite: Always plan, overwriting existing cache plans if better plan was found.
+    #   - TrainingAppendOnly: Always plan, append to cache if better plan was found (no overwriting).
+    #   - ExecuteBestEffort: Prioritize cached plans. Only plan if no cached plans found.
+    #   - ExecuteReadOnly: Only use cached plans. Fail if no cached plans found.
+    planner_database_mode: "TrainingOverwrite"
+    # Database type and location
+    cache_db_plugin: "warehouse_ros_sqlite::DatabaseConnection"
+    cache_db_host: ":memory:"
+    cache_db_port: 0  # Isn't used for SQLite3
+
+    # The cache keys cache entries on certain properties of the motion plan request's
+    # starting joint state, goal constraints, and more.
+
+    # For float comparisons, what tolerance counts as an exact match (to prevent floating point precision errors)
+    cache_exact_match_tolerance: 0.001  # ~0.05 degrees per joint
+    # Query range thresholds for matching attributes of the starting robot state for cache hits.
+    # This typically applies to joint states, per joint, in radians
+    #
+    # It should be acceptable to be more lenient on the start state, because the robot will be commanded
+    # to go to the first trajectory point from it's current start state.
+    cache_start_match_tolerance: 0.025
+    # Query range thresholds for matching attributes of the requested planning goals for cache hits.
+    # This typically applies to the x, y, z coordinates of the goal pose, in metres
+    # And also the individual quaternion components of the goal orientation
+    #
+    # Goal tolerances should be more strict so the end point of the robot remains consistent between
+    # the fetched plan and the desired goal.
+    cache_goal_match_tolerance: 0.001

--- a/nexus_motion_planner/package.xml
+++ b/nexus_motion_planner/package.xml
@@ -28,8 +28,14 @@
   <test_depend>abb_irb1300_10_115_moveit_config</test_depend>
   <test_depend>abb_irb1300_support</test_depend>
 
+  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_cmake_uncrustify</test_depend>
+  <test_depend>launch_pytest</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
+
+  <test_depend>moveit_configs_utils</test_depend>
+  <test_depend>moveit_resources</test_depend>
+  <test_depend>python3-pytest</test_depend>
   <test_depend>rmf_utils</test_depend>
 
   <export>

--- a/nexus_motion_planner/package.xml
+++ b/nexus_motion_planner/package.xml
@@ -37,6 +37,8 @@
   <test_depend>moveit_resources</test_depend>
   <test_depend>python3-pytest</test_depend>
   <test_depend>rmf_utils</test_depend>
+  <test_depend>robot_state_publisher</test_depend>
+  <test_depend>ros2_control</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/nexus_motion_planner/src/main.cpp
+++ b/nexus_motion_planner/src/main.cpp
@@ -27,7 +27,7 @@ int main(int argc, char** argv)
   setvbuf(stdout, NULL, _IONBF, BUFSIZ);
 
   rclcpp::init(argc, argv);
-  auto node = std::make_shared<MotionPlannerServer>();
+  auto node = std::make_shared<nexus::motion_planner::MotionPlannerServer>();
   rclcpp::spin(node->get_node_base_interface());
   rclcpp::shutdown();
   return 0;

--- a/nexus_motion_planner/src/motion_plan_cache.cpp
+++ b/nexus_motion_planner/src/motion_plan_cache.cpp
@@ -1,0 +1,918 @@
+#include <memory>
+#include <vector>
+
+#include "moveit/robot_state/conversions.h"
+#include "moveit/robot_state/robot_state.h"
+#include "warehouse_ros/database_loader.h"
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/logging.hpp"
+#include "motion_plan_cache.hpp"
+
+namespace nexus {
+namespace motion_planner {
+
+#define NEXUS_MATCH_RANGE(arg, tolerance) \
+  arg - tolerance / 2, arg + tolerance / 2
+
+using warehouse_ros::MessageWithMetadata;
+using warehouse_ros::Metadata;
+using warehouse_ros::Query;
+
+MotionPlanCache::MotionPlanCache(const rclcpp::Node::SharedPtr& node)
+: node_(node)
+{
+  // TODO: methyldragon -
+  //   Declare or pass in these in the motion_planner_server instead?
+  if (!node_->has_parameter("warehouse_plugin"))
+  {
+    node_->declare_parameter<std::string>(
+      "warehouse_plugin", "warehouse_ros_sqlite::DatabaseConnection");
+  }
+
+  tf_buffer_ =
+    std::make_unique<tf2_ros::Buffer>(node_->get_clock());
+  tf_listener_ =
+    std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
+
+  warehouse_ros::DatabaseLoader loader(node_);
+  db_ = loader.loadDatabase();
+}
+
+void MotionPlanCache::init(
+  const std::string& db_path, uint32_t db_port, double exact_match_precision)
+{
+  RCLCPP_INFO(
+    node_->get_logger(),
+    "Opening motion plan cache database at: %s (Port: %d, Precision: %f)",
+    db_path.c_str(), db_port, exact_match_precision);
+
+  exact_match_precision_ = exact_match_precision;
+  db_->setParams(db_path, db_port);
+  db_->connect();
+}
+
+// TOP LEVEL OPS ===============================================================
+std::vector<MessageWithMetadata<moveit_msgs::msg::RobotTrajectory>::ConstPtr>
+MotionPlanCache::fetchAllMatchingPlans(
+  const moveit::planning_interface::MoveGroupInterface& move_group,
+  const std::string& move_group_namespace,
+  const moveit_msgs::msg::MotionPlanRequest& plan_request,
+  double start_tolerance, double goal_tolerance, bool metadata_only)
+{
+  auto coll = db_->openCollection<moveit_msgs::msg::RobotTrajectory>(
+    "move_group_plan_cache", move_group_namespace);
+
+  Query::Ptr query = coll.createQuery();
+
+  bool start_ok = this->extractAndAppendStartToQuery(
+    *query, move_group, plan_request, start_tolerance);
+  bool goal_ok = this->extractAndAppendGoalToQuery(
+    *query, move_group, plan_request, goal_tolerance);
+
+  if (!start_ok || !goal_ok)
+  {
+    RCLCPP_ERROR(node_->get_logger(), "Could not construct plan query.");
+    return {};
+  }
+
+  return coll.queryList(
+    query, metadata_only, /* sort_by */ "execution_time_s", true);
+}
+
+MessageWithMetadata<moveit_msgs::msg::RobotTrajectory>::ConstPtr
+MotionPlanCache::fetchBestMatchingPlan(
+  const moveit::planning_interface::MoveGroupInterface& move_group,
+  const std::string& move_group_namespace,
+  const moveit_msgs::msg::MotionPlanRequest& plan_request,
+  double start_tolerance, double goal_tolerance, bool metadata_only)
+{
+  // First find all matching, but metadata only.
+  // Then use the ID metadata of the best plan to pull the actual message.
+  auto matching_plans = this->fetchAllMatchingPlans(
+    move_group, move_group_namespace,
+    plan_request, start_tolerance, goal_tolerance,
+    true);
+
+  if (matching_plans.empty())
+  {
+    RCLCPP_INFO(node_->get_logger(), "No matching plans found.");
+    return nullptr;
+  }
+
+  auto coll = db_->openCollection<moveit_msgs::msg::RobotTrajectory>(
+    "move_group_plan_cache", move_group_namespace);
+
+  // Best plan is at first index, since the lookup query was sorted by
+  // execution_time.
+  int best_plan_id = matching_plans.at(0)->lookupInt("id");
+  Query::Ptr best_query = coll.createQuery();
+  best_query->append("id", best_plan_id);
+
+  return coll.findOne(best_query, metadata_only);
+}
+
+bool
+MotionPlanCache::putPlan(
+  const moveit::planning_interface::MoveGroupInterface& move_group,
+  const std::string& move_group_namespace,
+  const moveit_msgs::msg::MotionPlanRequest& plan_request,
+  const moveit_msgs::msg::RobotTrajectory& plan,
+  double execution_time_s,
+  bool overwrite)
+{
+  // Check pre-conditions
+  if (!plan.multi_dof_joint_trajectory.points.empty())
+  {
+    RCLCPP_ERROR(
+      node_->get_logger(),
+      "Skipping insert: Multi-DOF trajectory plans are not supported.");
+    return false;
+  }
+  if (plan_request.workspace_parameters.header.frame_id.empty() ||
+    plan.joint_trajectory.header.frame_id.empty())
+  {
+    RCLCPP_ERROR(
+      node_->get_logger(), "Skipping insert: Frame IDs cannot be empty.");
+    return false;
+  }
+  if (plan_request.workspace_parameters.header.frame_id !=
+    plan.joint_trajectory.header.frame_id)
+  {
+    RCLCPP_ERROR(
+      node_->get_logger(),
+      "Skipping insert: "
+      "Plan request frame (%s) does not match plan frame (%s).",
+      plan_request.workspace_parameters.header.frame_id.c_str(),
+      plan.joint_trajectory.header.frame_id.c_str());
+    return false;
+  }
+
+  auto coll = db_->openCollection<moveit_msgs::msg::RobotTrajectory>(
+    "move_group_plan_cache", move_group_namespace);
+
+  // If start and goal are "exact" match, AND the candidate plan is better,
+  // overwrite.
+  Query::Ptr exact_query = coll.createQuery();
+
+  bool start_query_ok = this->extractAndAppendStartToQuery(
+    *exact_query, move_group,
+    plan_request, exact_match_precision_);
+  bool goal_query_ok = this->extractAndAppendGoalToQuery(
+    *exact_query, move_group,
+    plan_request, exact_match_precision_);
+
+  if (!start_query_ok || !goal_query_ok)
+  {
+    RCLCPP_ERROR(
+      node_->get_logger(),
+      "Skipping insert: Could not construct overwrite query.");
+    return false;
+  }
+
+  auto exact_matches = coll.queryList(exact_query, /* metadata_only */ true);
+  double best_execution_time_seen = std::numeric_limits<double>::infinity();
+  if (!exact_matches.empty())
+  {
+    for (auto& match : exact_matches)
+    {
+      double match_execution_time_s =
+        match->lookupDouble("execution_time_s");
+      if (match_execution_time_s < best_execution_time_seen)
+      {
+        best_execution_time_seen = match_execution_time_s;
+      }
+
+      if (match_execution_time_s > execution_time_s)
+      {
+        // If we found any "exact" matches that are worse, delete them.
+        if (overwrite)
+        {
+          int delete_id = match->lookupInt("id");
+          RCLCPP_INFO(
+            node_->get_logger(),
+            "Overwriting plan (id: %d): "
+            "execution_time (%es) > new plan's execution_time (%es)",
+            delete_id, match_execution_time_s, execution_time_s);
+
+          Query::Ptr delete_query = coll.createQuery();
+          delete_query->append("id", delete_id);
+          coll.removeMessages(delete_query);
+        }
+      }
+    }
+  }
+
+  // Insert if candidate is best seen.
+  if (execution_time_s < best_execution_time_seen)
+  {
+    Metadata::Ptr insert_metadata = coll.createMetadata();
+
+    bool start_meta_ok = this->extractAndAppendStartToMetadata(
+      *insert_metadata, move_group, plan_request);
+    bool goal_meta_ok = this->extractAndAppendGoalToMetadata(
+      *insert_metadata, move_group, plan_request);
+    insert_metadata->append("execution_time_s", execution_time_s);
+
+    if (!start_meta_ok || !goal_meta_ok)
+    {
+      RCLCPP_ERROR(
+        node_->get_logger(),
+        "Skipping insert: Could not construct insert metadata.");
+      return false;
+    }
+
+    RCLCPP_INFO(
+      node_->get_logger(),
+      "Inserting plan: New plan execution_time (%es) "
+      "is better than best plan's execution_time (%es)",
+      execution_time_s, best_execution_time_seen);
+
+    coll.insert(plan, insert_metadata);
+    return true;
+  }
+
+  RCLCPP_INFO(
+    node_->get_logger(),
+    "Skipping insert: New plan execution_time (%es) "
+    "is worse than best plan's execution_time (%es)",
+    execution_time_s, best_execution_time_seen);
+  return false;
+}
+
+// QUERY CONSTRUCTION ==========================================================
+bool
+MotionPlanCache::extractAndAppendStartToQuery(
+  Query& query,
+  const moveit::planning_interface::MoveGroupInterface& move_group,
+  const moveit_msgs::msg::MotionPlanRequest& plan_request,
+  double match_tolerance)
+{
+  match_tolerance += exact_match_precision_;
+
+  // Make ignored members explicit
+  if (!plan_request.start_state.multi_dof_joint_state.joint_names.empty())
+  {
+    RCLCPP_WARN(
+      node_->get_logger(),
+      "Ignoring start_state.multi_dof_joint_states: Not supported.");
+  }
+  if (!plan_request.start_state.attached_collision_objects.empty())
+  {
+    RCLCPP_WARN(
+      node_->get_logger(),
+      "Ignoring start_state.attached_collision_objects: Not supported.");
+  }
+
+  // auto original = *query;  // Copy not supported.
+
+  query.append("group_name", plan_request.group_name);
+
+  // Workspace params
+  // Match anything within our specified workspace limits.
+  query.append(
+    "workspace_parameters.header.frame_id",
+    plan_request.workspace_parameters.header.frame_id);
+  query.appendGTE(
+    "workspace_parameters.min_corner.x",
+    plan_request.workspace_parameters.min_corner.x);
+  query.appendGTE(
+    "workspace_parameters.min_corner.y",
+    plan_request.workspace_parameters.min_corner.y);
+  query.appendGTE(
+    "workspace_parameters.min_corner.z",
+    plan_request.workspace_parameters.min_corner.z);
+  query.appendLTE(
+    "workspace_parameters.max_corner.x",
+    plan_request.workspace_parameters.max_corner.x);
+  query.appendLTE(
+    "workspace_parameters.max_corner.y",
+    plan_request.workspace_parameters.max_corner.y);
+  query.appendLTE(
+    "workspace_parameters.max_corner.z",
+    plan_request.workspace_parameters.max_corner.z);
+
+  // Joint state
+  //   Only accounts for joint_state position. Ignores velocity and effort.
+  if (plan_request.start_state.is_diff)
+  {
+    // If plan request states that the start_state is_diff, then we need to get
+    // the current state from the move_group.
+
+    // NOTE: methyldragon -
+    //   I think if is_diff is on, the joint states will not be populated in all
+    //   of our motion plan requests? If this isn't the case we might need to
+    //   apply the joint states after as well.
+    moveit::core::RobotStatePtr current_state = move_group.getCurrentState();
+    if (!current_state)
+    {
+      RCLCPP_WARN(
+        node_->get_logger(),
+        "Skipping start query append: Could not get robot state.");
+      // *query = original;  // Undo our changes. (Can't. Copy not supported.)
+      return false;
+    }
+
+    moveit_msgs::msg::RobotState current_state_msg;
+    robotStateToRobotStateMsg(*current_state, current_state_msg);
+
+    for (size_t i = 0; i < current_state_msg.joint_state.name.size(); i++)
+    {
+      query.append(
+        "start_state.joint_state.name_" + std::to_string(i),
+        current_state_msg.joint_state.name.at(i));
+      query.appendRangeInclusive(
+        "start_state.joint_state.position_" + std::to_string(i),
+        NEXUS_MATCH_RANGE(
+          current_state_msg.joint_state.position.at(i), match_tolerance)
+      );
+    }
+  }
+  else
+  {
+    for (
+      size_t i = 0; i < plan_request.start_state.joint_state.name.size(); i++
+    )
+    {
+      query.append(
+        "start_state.joint_state.name_" + std::to_string(i),
+        plan_request.start_state.joint_state.name.at(i));
+      query.appendRangeInclusive(
+        "start_state.joint_state.position_" + std::to_string(i),
+        NEXUS_MATCH_RANGE(
+          plan_request.start_state.joint_state.position.at(i), match_tolerance)
+      );
+    }
+  }
+  return true;
+}
+
+bool
+MotionPlanCache::extractAndAppendGoalToQuery(
+  Query& query,
+  const moveit::planning_interface::MoveGroupInterface& /* move_group */,
+  const moveit_msgs::msg::MotionPlanRequest& plan_request,
+  double match_tolerance)
+{
+  match_tolerance += exact_match_precision_;
+
+  // Make ignored members explicit
+  bool emit_position_constraint_warning = false;
+  for (auto& constraint : plan_request.goal_constraints)
+  {
+    for (auto& position_constraint : constraint.position_constraints)
+    {
+      if (!position_constraint.constraint_region.primitives.empty())
+      {
+        emit_position_constraint_warning = true;
+        break;
+      }
+    }
+    if (emit_position_constraint_warning)
+    {
+      break;
+    }
+  }
+  if (emit_position_constraint_warning)
+  {
+    RCLCPP_WARN(
+      node_->get_logger(),
+      "Ignoring goal_constraints.position_constraints.constraint_region: "
+      "Not supported.");
+  }
+
+  // auto original = *query;  // Copy not supported.
+
+  query.appendRangeInclusive(
+    "max_velocity_scaling_factor",
+    NEXUS_MATCH_RANGE(
+      plan_request.max_velocity_scaling_factor, match_tolerance)
+  );
+  query.appendRangeInclusive(
+    "max_acceleration_scaling_factor",
+    NEXUS_MATCH_RANGE(
+      plan_request.max_acceleration_scaling_factor, match_tolerance)
+  );
+  query.appendRangeInclusive(
+    "max_cartesian_speed",
+    NEXUS_MATCH_RANGE(plan_request.max_cartesian_speed, match_tolerance));
+
+  // Extract constraints (so we don't have cardinality on goal_constraint idx.)
+  std::vector<moveit_msgs::msg::JointConstraint> joint_constraints;
+  std::vector<moveit_msgs::msg::PositionConstraint> position_constraints;
+  std::vector<moveit_msgs::msg::OrientationConstraint> orientation_constraints;
+  for (auto& constraint : plan_request.goal_constraints)
+  {
+    for (auto& joint_constraint : constraint.joint_constraints)
+    {
+      joint_constraints.push_back(joint_constraint);
+    }
+    for (auto& position_constraint : constraint.position_constraints)
+    {
+      position_constraints.push_back(position_constraint);
+    }
+    for (auto& orientation_constraint : constraint.orientation_constraints)
+    {
+      orientation_constraints.push_back(orientation_constraint);
+    }
+  }
+
+  // Joint constraints
+  size_t joint_idx = 0;
+  for (auto& constraint : joint_constraints)
+  {
+    std::string meta_name =
+      "goal_constraints.joint_constraints_" + std::to_string(joint_idx++);
+
+    query.append(meta_name + ".joint_name", constraint.joint_name);
+    query.appendRangeInclusive(
+      meta_name + ".position",
+      NEXUS_MATCH_RANGE(constraint.position, match_tolerance));
+    query.appendGTE(
+      meta_name + ".tolerance_above", constraint.tolerance_above);
+    query.appendLTE(
+      meta_name + ".tolerance_below", constraint.tolerance_below);
+  }
+
+  // Position constraints
+  // All offsets will be "frozen" and computed wrt. the workspace frame
+  // instead.
+  if (!position_constraints.empty())
+  {
+    query.append(
+      "goal_constraints.position_constraints.header.frame_id",
+      plan_request.workspace_parameters.header.frame_id);
+
+    size_t pos_idx = 0;
+    for (auto& constraint : position_constraints)
+    {
+      std::string meta_name =
+        "goal_constraints.position_constraints_" + std::to_string(pos_idx++);
+
+      // Compute offsets wrt. to workspace frame.
+      double x_offset = 0;
+      double y_offset = 0;
+      double z_offset = 0;
+
+      if (plan_request.workspace_parameters.header.frame_id !=
+        constraint.header.frame_id)
+      {
+        try
+        {
+          auto transform = tf_buffer_->lookupTransform(
+            constraint.header.frame_id,
+            plan_request.workspace_parameters.header.frame_id,
+            tf2::TimePointZero);
+
+          x_offset = transform.transform.translation.x;
+          y_offset = transform.transform.translation.y;
+          z_offset = transform.transform.translation.z;
+        }
+        catch (tf2::TransformException& ex)
+        {
+          RCLCPP_WARN(
+            node_->get_logger(),
+            "Skipping goal query append: "
+            "Could not get goal transform for translation %s to %s: %s",
+            plan_request.workspace_parameters.header.frame_id.c_str(),
+            constraint.header.frame_id.c_str(),
+            ex.what());
+
+          // (Can't. Copy not supported.)
+          // *query = original;  // Undo our changes.
+          return false;
+        }
+      }
+
+      query.append(meta_name + ".link_name", constraint.link_name);
+
+      query.appendRangeInclusive(
+        meta_name + ".target_point_offset.x",
+        NEXUS_MATCH_RANGE(
+          x_offset + constraint.target_point_offset.x, match_tolerance));
+      query.appendRangeInclusive(
+        meta_name + ".target_point_offset.y",
+        NEXUS_MATCH_RANGE(
+          y_offset + constraint.target_point_offset.y, match_tolerance));
+      query.appendRangeInclusive(
+        meta_name + ".target_point_offset.z",
+        NEXUS_MATCH_RANGE(
+          z_offset + constraint.target_point_offset.z, match_tolerance));
+    }
+  }
+
+  // Orientation constraints
+  // All offsets will be "frozen" and computed wrt. the workspace frame
+  // instead.
+  if (!orientation_constraints.empty())
+  {
+    query.append(
+      "goal_constraints.orientation_constraints.header.frame_id",
+      plan_request.workspace_parameters.header.frame_id);
+
+    size_t ori_idx = 0;
+    for (auto& constraint : orientation_constraints)
+    {
+      std::string meta_name =
+        "goal_constraints.orientation_constraints_" + std::to_string(ori_idx++);
+
+      // Compute offsets wrt. to workspace frame.
+      geometry_msgs::msg::Quaternion quat_offset;
+      quat_offset.x = 0;
+      quat_offset.y = 0;
+      quat_offset.z = 0;
+      quat_offset.w = 1;
+
+      if (plan_request.workspace_parameters.header.frame_id !=
+        constraint.header.frame_id)
+      {
+        try
+        {
+          auto transform = tf_buffer_->lookupTransform(
+            constraint.header.frame_id,
+            plan_request.workspace_parameters.header.frame_id,
+            tf2::TimePointZero);
+
+          quat_offset = transform.transform.rotation;
+        }
+        catch (tf2::TransformException& ex)
+        {
+          RCLCPP_WARN(
+            node_->get_logger(),
+            "Skipping goal query append: "
+            "Could not get goal transform for orientation %s to %s: %s",
+            plan_request.workspace_parameters.header.frame_id.c_str(),
+            constraint.header.frame_id.c_str(),
+            ex.what());
+
+          // (Can't. Copy not supported.)
+          // *query = original;  // Undo our changes.
+          return false;
+        }
+      }
+
+      query.append(meta_name + ".link_name", constraint.link_name);
+
+      // Orientation of constraint frame wrt. workspace frame
+      tf2::Quaternion tf2_quat_frame_offset(
+        quat_offset.x, quat_offset.y, quat_offset.z, quat_offset.w);
+
+      // Added offset on top of the constraint frame's orientation stated in
+      // the constraint.
+      tf2::Quaternion tf2_quat_goal_offset(
+        constraint.orientation.x,
+        constraint.orientation.y,
+        constraint.orientation.z,
+        constraint.orientation.w);
+
+      tf2_quat_frame_offset.normalize();
+      tf2_quat_goal_offset.normalize();
+
+      auto final_quat = tf2_quat_goal_offset * tf2_quat_frame_offset;
+      final_quat.normalize();
+
+      query.appendRangeInclusive(
+        meta_name + ".target_point_offset.x",
+        NEXUS_MATCH_RANGE(final_quat.getX(), match_tolerance));
+      query.appendRangeInclusive(
+        meta_name + ".target_point_offset.y",
+        NEXUS_MATCH_RANGE(final_quat.getY(), match_tolerance));
+      query.appendRangeInclusive(
+        meta_name + ".target_point_offset.z",
+        NEXUS_MATCH_RANGE(final_quat.getZ(), match_tolerance));
+      query.appendRangeInclusive(
+        meta_name + ".target_point_offset.w",
+        NEXUS_MATCH_RANGE(final_quat.getW(), match_tolerance));
+    }
+  }
+
+  return true;
+}
+
+// METADATA CONSTRUCTION =======================================================
+bool
+MotionPlanCache::extractAndAppendStartToMetadata(
+  Metadata& metadata,
+  const moveit::planning_interface::MoveGroupInterface& move_group,
+  const moveit_msgs::msg::MotionPlanRequest& plan_request)
+{
+  // Make ignored members explicit
+  if (!plan_request.start_state.multi_dof_joint_state.joint_names.empty())
+  {
+    RCLCPP_WARN(
+      node_->get_logger(),
+      "Ignoring start_state.multi_dof_joint_states: Not supported.");
+  }
+  if (!plan_request.start_state.attached_collision_objects.empty())
+  {
+    RCLCPP_WARN(
+      node_->get_logger(),
+      "Ignoring start_state.attached_collision_objects: Not supported.");
+  }
+
+  // auto original = *metadata;  // Copy not supported.
+
+  metadata.append("group_name", plan_request.group_name);
+
+  // Workspace params
+  metadata.append(
+    "workspace_parameters.header.frame_id",
+    plan_request.workspace_parameters.header.frame_id);
+  metadata.append(
+    "workspace_parameters.min_corner.x",
+    plan_request.workspace_parameters.min_corner.x);
+  metadata.append(
+    "workspace_parameters.min_corner.y",
+    plan_request.workspace_parameters.min_corner.y);
+  metadata.append(
+    "workspace_parameters.min_corner.z",
+    plan_request.workspace_parameters.min_corner.z);
+  metadata.append(
+    "workspace_parameters.max_corner.x",
+    plan_request.workspace_parameters.max_corner.x);
+  metadata.append(
+    "workspace_parameters.max_corner.y",
+    plan_request.workspace_parameters.max_corner.y);
+  metadata.append(
+    "workspace_parameters.max_corner.z",
+    plan_request.workspace_parameters.max_corner.z);
+
+  // Joint state
+  //   Only accounts for joint_state position. Ignores velocity and effort.
+  if (plan_request.start_state.is_diff)
+  {
+    // If plan request states that the start_state is_diff, then we need to get
+    // the current state from the move_group.
+
+    // NOTE: methyldragon -
+    //   I think if is_diff is on, the joint states will not be populated in all
+    //   of our motion plan requests? If this isn't the case we might need to
+    //   apply the joint states after as well.
+    moveit::core::RobotStatePtr current_state = move_group.getCurrentState();
+    if (!current_state)
+    {
+      RCLCPP_WARN(
+        node_->get_logger(),
+        "Skipping start metadata append: Could not get robot state.");
+      // *metadata = original;  // Undo our changes.  // Copy not supported
+      return false;
+    }
+
+    moveit_msgs::msg::RobotState current_state_msg;
+    robotStateToRobotStateMsg(*current_state, current_state_msg);
+
+    for (size_t i = 0; i < current_state_msg.joint_state.name.size(); i++)
+    {
+      metadata.append(
+        "start_state.joint_state.name_" + std::to_string(i),
+        current_state_msg.joint_state.name.at(i));
+      metadata.append(
+        "start_state.joint_state.position_" + std::to_string(i),
+        current_state_msg.joint_state.position.at(i));
+    }
+  }
+  else
+  {
+    for (
+      size_t i = 0; i < plan_request.start_state.joint_state.name.size(); i++
+    )
+    {
+      metadata.append(
+        "start_state.joint_state.name_" + std::to_string(i),
+        plan_request.start_state.joint_state.name.at(i));
+      metadata.append(
+        "start_state.joint_state.position_" + std::to_string(i),
+        plan_request.start_state.joint_state.position.at(i));
+    }
+  }
+
+  return true;
+}
+
+bool
+MotionPlanCache::extractAndAppendGoalToMetadata(
+  Metadata& metadata,
+  const moveit::planning_interface::MoveGroupInterface& /* move_group */,
+  const moveit_msgs::msg::MotionPlanRequest& plan_request)
+{
+  // Make ignored members explicit
+  bool emit_position_constraint_warning = false;
+  for (auto& constraint : plan_request.goal_constraints)
+  {
+    for (auto& position_constraint : constraint.position_constraints)
+    {
+      if (!position_constraint.constraint_region.primitives.empty())
+      {
+        emit_position_constraint_warning = true;
+        break;
+      }
+    }
+    if (emit_position_constraint_warning)
+    {
+      break;
+    }
+  }
+  if (emit_position_constraint_warning)
+  {
+    RCLCPP_WARN(
+      node_->get_logger(),
+      "Ignoring goal_constraints.position_constraints.constraint_region: "
+      "Not supported.");
+  }
+
+  // auto original = *metadata;  // Copy not supported.
+
+  metadata.append("max_velocity_scaling_factor",
+    plan_request.max_velocity_scaling_factor);
+  metadata.append("max_acceleration_scaling_factor",
+    plan_request.max_acceleration_scaling_factor);
+  metadata.append("max_cartesian_speed", plan_request.max_cartesian_speed);
+
+  // Extract constraints (so we don't have cardinality on goal_constraint idx.)
+  std::vector<moveit_msgs::msg::JointConstraint> joint_constraints;
+  std::vector<moveit_msgs::msg::PositionConstraint> position_constraints;
+  std::vector<moveit_msgs::msg::OrientationConstraint> orientation_constraints;
+  for (auto& constraint : plan_request.goal_constraints)
+  {
+    for (auto& joint_constraint : constraint.joint_constraints)
+    {
+      joint_constraints.push_back(joint_constraint);
+    }
+    for (auto& position_constraint : constraint.position_constraints)
+    {
+      position_constraints.push_back(position_constraint);
+    }
+    for (auto& orientation_constraint : constraint.orientation_constraints)
+    {
+      orientation_constraints.push_back(orientation_constraint);
+    }
+  }
+
+  // Joint constraints
+  size_t joint_idx = 0;
+  for (auto& constraint : joint_constraints)
+  {
+    std::string meta_name =
+      "goal_constraints.joint_constraints_" + std::to_string(joint_idx++);
+
+    metadata.append(meta_name + ".joint_name", constraint.joint_name);
+    metadata.append(meta_name + ".position", constraint.position);
+    metadata.append(
+      meta_name + ".tolerance_above", constraint.tolerance_above);
+    metadata.append(
+      meta_name + ".tolerance_below", constraint.tolerance_below);
+  }
+
+  // Position constraints
+  if (!position_constraints.empty())
+  {
+    // All offsets will be "frozen" and computed wrt. the workspace frame
+    // instead.
+    metadata.append(
+      "goal_constraints.position_constraints.header.frame_id",
+      plan_request.workspace_parameters.header.frame_id);
+
+    size_t position_idx = 0;
+    for (auto& constraint : position_constraints)
+    {
+      std::string meta_name =
+        "goal_constraints.position_constraints_"
+        + std::to_string(position_idx++);
+
+      // Compute offsets wrt. to workspace frame.
+      double x_offset = 0;
+      double y_offset = 0;
+      double z_offset = 0;
+
+      if (plan_request.workspace_parameters.header.frame_id !=
+        constraint.header.frame_id)
+      {
+        try
+        {
+          auto transform = tf_buffer_->lookupTransform(
+            constraint.header.frame_id,
+            plan_request.workspace_parameters.header.frame_id,
+            tf2::TimePointZero);
+
+          x_offset = transform.transform.translation.x;
+          y_offset = transform.transform.translation.y;
+          z_offset = transform.transform.translation.z;
+        }
+        catch (tf2::TransformException& ex)
+        {
+          RCLCPP_WARN(
+            node_->get_logger(),
+            "Skipping goal metadata append: "
+            "Could not get goal transform for translation %s to %s: %s",
+            plan_request.workspace_parameters.header.frame_id.c_str(),
+            constraint.header.frame_id.c_str(),
+            ex.what());
+
+          // (Can't. Copy not supported.)
+          // *metadata = original;  // Undo our changes.
+          return false;
+        }
+      }
+
+      metadata.append(meta_name + ".link_name", constraint.link_name);
+
+      metadata.append(
+        meta_name + ".target_point_offset.x",
+        x_offset + constraint.target_point_offset.x);
+      metadata.append(
+        meta_name + ".target_point_offset.y",
+        y_offset + constraint.target_point_offset.y);
+      metadata.append(
+        meta_name + ".target_point_offset.z",
+        z_offset + constraint.target_point_offset.z);
+    }
+  }
+
+  // Orientation constraints
+  if (!orientation_constraints.empty())
+  {
+    // All offsets will be "frozen" and computed wrt. the workspace frame
+    // instead.
+    metadata.append(
+      "goal_constraints.orientation_constraints.header.frame_id",
+      plan_request.workspace_parameters.header.frame_id);
+
+    size_t ori_idx = 0;
+    for (auto& constraint : orientation_constraints)
+    {
+      std::string meta_name =
+        "goal_constraints.orientation_constraints_" + std::to_string(ori_idx++);
+
+      // Compute offsets wrt. to workspace frame.
+      geometry_msgs::msg::Quaternion quat_offset;
+      quat_offset.x = 0;
+      quat_offset.y = 0;
+      quat_offset.z = 0;
+      quat_offset.w = 1;
+
+      if (plan_request.workspace_parameters.header.frame_id !=
+        constraint.header.frame_id)
+      {
+        try
+        {
+          auto transform = tf_buffer_->lookupTransform(
+            constraint.header.frame_id,
+            plan_request.workspace_parameters.header.frame_id,
+            tf2::TimePointZero);
+
+          quat_offset = transform.transform.rotation;
+        }
+        catch (tf2::TransformException& ex)
+        {
+          RCLCPP_WARN(
+            node_->get_logger(),
+            "Skipping goal metadata append: "
+            "Could not get goal transform for orientation %s to %s: %s",
+            plan_request.workspace_parameters.header.frame_id.c_str(),
+            constraint.header.frame_id.c_str(),
+            ex.what());
+
+          // (Can't. Copy not supported.)
+          // *metadata = original;  // Undo our changes.
+          return false;
+        }
+      }
+
+      metadata.append(meta_name + ".link_name", constraint.link_name);
+
+      // Orientation of constraint frame wrt. workspace frame
+      tf2::Quaternion tf2_quat_frame_offset(
+        quat_offset.x, quat_offset.y, quat_offset.z, quat_offset.w);
+
+      // Added offset on top of the constraint frame's orientation stated in
+      // the constraint.
+      tf2::Quaternion tf2_quat_goal_offset(
+        constraint.orientation.x,
+        constraint.orientation.y,
+        constraint.orientation.z,
+        constraint.orientation.w);
+
+      tf2_quat_frame_offset.normalize();
+      tf2_quat_goal_offset.normalize();
+
+      auto final_quat = tf2_quat_goal_offset * tf2_quat_frame_offset;
+      final_quat.normalize();
+
+      metadata.append(meta_name + ".target_point_offset.x",
+        final_quat.getX());
+      metadata.append(meta_name + ".target_point_offset.y",
+        final_quat.getY());
+      metadata.append(meta_name + ".target_point_offset.z",
+        final_quat.getZ());
+      metadata.append(meta_name + ".target_point_offset.w",
+        final_quat.getW());
+    }
+  }
+
+  return true;
+}
+
+#undef NEXUS_MATCH_RANGE
+
+}  // namespace motion_planner
+}  // namespace nexus

--- a/nexus_motion_planner/src/motion_plan_cache.cpp
+++ b/nexus_motion_planner/src/motion_plan_cache.cpp
@@ -26,32 +26,71 @@
 namespace nexus {
 namespace motion_planner {
 
-#define NEXUS_MATCH_RANGE(arg, tolerance) \
-  arg - tolerance / 2, arg + tolerance / 2
-
 using warehouse_ros::MessageWithMetadata;
 using warehouse_ros::Metadata;
 using warehouse_ros::Query;
 
+// Utils =======================================================================
+
+// Append a range inclusive query with some tolerance about some center value.
+void query_append_range_inclusive_with_tolerance(
+  Query& query, const std::string& name, double center, double tolerance)
+{
+  query.appendRangeInclusive(
+    name, center - tolerance / 2, center + tolerance / 2);
+}
+
+// Sort constraint components by joint or link name.
+void sort_constraints(
+  std::vector<moveit_msgs::msg::JointConstraint>& joint_constraints,
+  std::vector<moveit_msgs::msg::PositionConstraint>& position_constraints,
+  std::vector<moveit_msgs::msg::OrientationConstraint>& orientation_constraints)
+{
+  std::sort(
+    joint_constraints.begin(), joint_constraints.end(),
+    [](
+      const moveit_msgs::msg::JointConstraint& l,
+      const moveit_msgs::msg::JointConstraint& r)
+    {
+      return l.joint_name < r.joint_name;
+    });
+
+  std::sort(
+    position_constraints.begin(), position_constraints.end(),
+    [](
+      const moveit_msgs::msg::PositionConstraint& l,
+      const moveit_msgs::msg::PositionConstraint& r)
+    {
+      return l.link_name < r.link_name;
+    });
+
+  std::sort(
+    orientation_constraints.begin(), orientation_constraints.end(),
+    [](
+      const moveit_msgs::msg::OrientationConstraint& l,
+      const moveit_msgs::msg::OrientationConstraint& r)
+    {
+      return l.link_name < r.link_name;
+    });
+}
+
+// Motion Plan Cache ===========================================================
+
 MotionPlanCache::MotionPlanCache(const rclcpp::Node::SharedPtr& node)
 : node_(node)
 {
-  if (!node_->has_parameter("warehouse_plugin"))
-  {
-    node_->declare_parameter<std::string>(
-      "warehouse_plugin", "warehouse_ros_sqlite::DatabaseConnection");
-  }
-
   tf_buffer_ =
     std::make_unique<tf2_ros::Buffer>(node_->get_clock());
   tf_listener_ =
     std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
 
+  // If the `warehouse_plugin` parameter isn't set, defaults to warehouse_ros'
+  // default.
   warehouse_ros::DatabaseLoader loader(node_);
   db_ = loader.loadDatabase();
 }
 
-void MotionPlanCache::init(
+bool MotionPlanCache::init(
   const std::string& db_path, uint32_t db_port, double exact_match_precision)
 {
   RCLCPP_INFO(
@@ -61,7 +100,23 @@ void MotionPlanCache::init(
 
   exact_match_precision_ = exact_match_precision;
   db_->setParams(db_path, db_port);
-  db_->connect();
+  return db_->connect();
+}
+
+unsigned
+MotionPlanCache::count_plans(const std::string& move_group_namespace)
+{
+  auto coll = db_->openCollection<moveit_msgs::msg::RobotTrajectory>(
+    "move_group_plan_cache", move_group_namespace);
+  return coll.count();
+}
+
+unsigned
+MotionPlanCache::count_cartesian_plans(const std::string& move_group_namespace)
+{
+  auto coll = db_->openCollection<moveit_msgs::msg::RobotTrajectory>(
+    "move_group_cartesian_plan_cache", move_group_namespace);
+  return coll.count();
 }
 
 // =============================================================================
@@ -73,7 +128,8 @@ MotionPlanCache::fetch_all_matching_plans(
   const moveit::planning_interface::MoveGroupInterface& move_group,
   const std::string& move_group_namespace,
   const moveit_msgs::msg::MotionPlanRequest& plan_request,
-  double start_tolerance, double goal_tolerance, bool metadata_only)
+  double start_tolerance, double goal_tolerance, bool metadata_only,
+  const std::string& sort_by)
 {
   auto coll = db_->openCollection<moveit_msgs::msg::RobotTrajectory>(
     "move_group_plan_cache", move_group_namespace);
@@ -91,8 +147,7 @@ MotionPlanCache::fetch_all_matching_plans(
     return {};
   }
 
-  return coll.queryList(
-    query, metadata_only, /* sort_by */ "execution_time_s", true);
+  return coll.queryList(query, metadata_only, sort_by, true);
 }
 
 MessageWithMetadata<moveit_msgs::msg::RobotTrajectory>::ConstPtr
@@ -100,14 +155,14 @@ MotionPlanCache::fetch_best_matching_plan(
   const moveit::planning_interface::MoveGroupInterface& move_group,
   const std::string& move_group_namespace,
   const moveit_msgs::msg::MotionPlanRequest& plan_request,
-  double start_tolerance, double goal_tolerance, bool metadata_only)
+  double start_tolerance, double goal_tolerance, bool metadata_only,
+  const std::string& sort_by)
 {
   // First find all matching, but metadata only.
   // Then use the ID metadata of the best plan to pull the actual message.
   auto matching_plans = this->fetch_all_matching_plans(
     move_group, move_group_namespace,
-    plan_request, start_tolerance, goal_tolerance,
-    true);
+    plan_request, start_tolerance, goal_tolerance, true, sort_by);
 
   if (matching_plans.empty())
   {
@@ -133,23 +188,21 @@ MotionPlanCache::put_plan(
   const std::string& move_group_namespace,
   const moveit_msgs::msg::MotionPlanRequest& plan_request,
   const moveit_msgs::msg::RobotTrajectory& plan,
-  double execution_time_s,
-  double planning_time_s,
-  bool overwrite)
+  double execution_time_s, double planning_time_s, bool delete_worse_plans)
 {
   // Check pre-conditions
   if (!plan.multi_dof_joint_trajectory.points.empty())
   {
     RCLCPP_ERROR(
       node_->get_logger(),
-      "Skipping insert: Multi-DOF trajectory plans are not supported.");
+      "Skipping plan insert: Multi-DOF trajectory plans are not supported.");
     return false;
   }
   if (plan_request.workspace_parameters.header.frame_id.empty() ||
     plan.joint_trajectory.header.frame_id.empty())
   {
     RCLCPP_ERROR(
-      node_->get_logger(), "Skipping insert: Frame IDs cannot be empty.");
+      node_->get_logger(), "Skipping plan insert: Frame IDs cannot be empty.");
     return false;
   }
   if (plan_request.workspace_parameters.header.frame_id !=
@@ -157,7 +210,7 @@ MotionPlanCache::put_plan(
   {
     RCLCPP_ERROR(
       node_->get_logger(),
-      "Skipping insert: "
+      "Skipping plan insert: "
       "Plan request frame (%s) does not match plan frame (%s).",
       plan_request.workspace_parameters.header.frame_id.c_str(),
       plan.joint_trajectory.header.frame_id.c_str());
@@ -167,42 +220,36 @@ MotionPlanCache::put_plan(
   auto coll = db_->openCollection<moveit_msgs::msg::RobotTrajectory>(
     "move_group_plan_cache", move_group_namespace);
 
-  // If start and goal are "exact" match, AND the candidate plan is better,
-  // overwrite.
+  // Pull out plans "exactly" keyed by request in cache.
   Query::Ptr exact_query = coll.createQuery();
 
   bool start_query_ok = this->extract_and_append_plan_start_to_query(
-    *exact_query, move_group,
-    plan_request, exact_match_precision_);
+    *exact_query, move_group, plan_request, 0);
   bool goal_query_ok = this->extract_and_append_plan_goal_to_query(
-    *exact_query, move_group,
-    plan_request, exact_match_precision_);
+    *exact_query, move_group, plan_request, 0);
 
   if (!start_query_ok || !goal_query_ok)
   {
     RCLCPP_ERROR(
       node_->get_logger(),
-      "Skipping insert: Could not construct overwrite query.");
+      "Skipping plan insert: Could not construct lookup query.");
     return false;
   }
 
-  auto exact_matches = coll.queryList(exact_query, /* metadata_only */ true);
-  double best_execution_time_seen = std::numeric_limits<double>::infinity();
+  auto exact_matches = coll.queryList(
+    exact_query, /* metadata_only */ true, /* sort_by */ "execution_time_s");
+
+  double best_execution_time = std::numeric_limits<double>::infinity();
   if (!exact_matches.empty())
   {
-    for (auto& match : exact_matches)
-    {
-      double match_execution_time_s =
-        match->lookupDouble("execution_time_s");
-      if (match_execution_time_s < best_execution_time_seen)
-      {
-        best_execution_time_seen = match_execution_time_s;
-      }
+    best_execution_time = exact_matches.at(0)->lookupDouble("execution_time_s");
 
-      if (match_execution_time_s > execution_time_s)
+    if (delete_worse_plans)
+    {
+      for (auto& match : exact_matches)
       {
-        // If we found any "exact" matches that are worse, delete them.
-        if (overwrite)
+        double match_execution_time_s = match->lookupDouble("execution_time_s");
+        if (execution_time_s < match_execution_time_s)
         {
           int delete_id = match->lookupInt("id");
           RCLCPP_INFO(
@@ -220,7 +267,7 @@ MotionPlanCache::put_plan(
   }
 
   // Insert if candidate is best seen.
-  if (execution_time_s < best_execution_time_seen)
+  if (execution_time_s < best_execution_time)
   {
     Metadata::Ptr insert_metadata = coll.createMetadata();
 
@@ -235,7 +282,7 @@ MotionPlanCache::put_plan(
     {
       RCLCPP_ERROR(
         node_->get_logger(),
-        "Skipping insert: Could not construct insert metadata.");
+        "Skipping plan insert: Could not construct insert metadata.");
       return false;
     }
 
@@ -243,7 +290,7 @@ MotionPlanCache::put_plan(
       node_->get_logger(),
       "Inserting plan: New plan execution_time (%es) "
       "is better than best plan's execution_time (%es)",
-      execution_time_s, best_execution_time_seen);
+      execution_time_s, best_execution_time);
 
     coll.insert(plan, insert_metadata);
     return true;
@@ -251,9 +298,9 @@ MotionPlanCache::put_plan(
 
   RCLCPP_INFO(
     node_->get_logger(),
-    "Skipping insert: New plan execution_time (%es) "
+    "Skipping plan insert: New plan execution_time (%es) "
     "is worse than best plan's execution_time (%es)",
-    execution_time_s, best_execution_time_seen);
+    execution_time_s, best_execution_time);
   return false;
 }
 
@@ -320,6 +367,13 @@ MotionPlanCache::extract_and_append_plan_start_to_query(
     //   I think if is_diff is on, the joint states will not be populated in all
     //   of our motion plan requests? If this isn't the case we might need to
     //   apply the joint states as offsets as well.
+    //
+    // TODO: Since MoveIt also potentially does another getCurrentState() call
+    //   when planning, there is a chance that the current state in the cache
+    //   differs from the state used in MoveIt's plan.
+    //
+    //   When upstreaming this class to MoveIt, this issue should go away once
+    //   the class is used within the move group's Plan call.
     moveit::core::RobotStatePtr current_state = move_group.getCurrentState();
     if (!current_state)
     {
@@ -338,11 +392,9 @@ MotionPlanCache::extract_and_append_plan_start_to_query(
       query.append(
         "start_state.joint_state.name_" + std::to_string(i),
         current_state_msg.joint_state.name.at(i));
-      query.appendRangeInclusive(
-        "start_state.joint_state.position_" + std::to_string(i),
-        NEXUS_MATCH_RANGE(
-          current_state_msg.joint_state.position.at(i), match_tolerance)
-      );
+      query_append_range_inclusive_with_tolerance(
+        query, "start_state.joint_state.position_" + std::to_string(i),
+        current_state_msg.joint_state.position.at(i), match_tolerance);
     }
   }
   else
@@ -354,11 +406,9 @@ MotionPlanCache::extract_and_append_plan_start_to_query(
       query.append(
         "start_state.joint_state.name_" + std::to_string(i),
         plan_request.start_state.joint_state.name.at(i));
-      query.appendRangeInclusive(
-        "start_state.joint_state.position_" + std::to_string(i),
-        NEXUS_MATCH_RANGE(
-          plan_request.start_state.joint_state.position.at(i), match_tolerance)
-      );
+      query_append_range_inclusive_with_tolerance(
+        query, "start_state.joint_state.position_" + std::to_string(i),
+        plan_request.start_state.joint_state.position.at(i), match_tolerance);
     }
   }
   return true;
@@ -400,19 +450,15 @@ MotionPlanCache::extract_and_append_plan_goal_to_query(
 
   // auto original = *query;  // Copy not supported.
 
-  query.appendRangeInclusive(
-    "max_velocity_scaling_factor",
-    NEXUS_MATCH_RANGE(
-      plan_request.max_velocity_scaling_factor, match_tolerance)
-  );
-  query.appendRangeInclusive(
-    "max_acceleration_scaling_factor",
-    NEXUS_MATCH_RANGE(
-      plan_request.max_acceleration_scaling_factor, match_tolerance)
-  );
-  query.appendRangeInclusive(
-    "max_cartesian_speed",
-    NEXUS_MATCH_RANGE(plan_request.max_cartesian_speed, match_tolerance));
+  query_append_range_inclusive_with_tolerance(
+    query, "max_velocity_scaling_factor",
+    plan_request.max_velocity_scaling_factor, match_tolerance);
+  query_append_range_inclusive_with_tolerance(
+    query, "max_acceleration_scaling_factor",
+    plan_request.max_acceleration_scaling_factor, match_tolerance);
+  query_append_range_inclusive_with_tolerance(
+    query, "max_cartesian_speed",
+    plan_request.max_cartesian_speed, match_tolerance);
 
   // Extract constraints (so we don't have cardinality on goal_constraint idx.)
   std::vector<moveit_msgs::msg::JointConstraint> joint_constraints;
@@ -432,6 +478,10 @@ MotionPlanCache::extract_and_append_plan_goal_to_query(
     {
       orientation_constraints.push_back(orientation_constraint);
     }
+
+    // Also sort for even less cardinality.
+    sort_constraints(
+      joint_constraints, position_constraints, orientation_constraints);
   }
 
   // Joint constraints
@@ -442,13 +492,10 @@ MotionPlanCache::extract_and_append_plan_goal_to_query(
       "goal_constraints.joint_constraints_" + std::to_string(joint_idx++);
 
     query.append(meta_name + ".joint_name", constraint.joint_name);
-    query.appendRangeInclusive(
-      meta_name + ".position",
-      NEXUS_MATCH_RANGE(constraint.position, match_tolerance));
-    query.appendGTE(
-      meta_name + ".tolerance_above", constraint.tolerance_above);
-    query.appendLTE(
-      meta_name + ".tolerance_below", constraint.tolerance_below);
+    query_append_range_inclusive_with_tolerance(
+      query, meta_name + ".position", constraint.position, match_tolerance);
+    query.appendGTE(meta_name + ".tolerance_above", constraint.tolerance_above);
+    query.appendLTE(meta_name + ".tolerance_below", constraint.tolerance_below);
   }
 
   // Position constraints
@@ -503,18 +550,15 @@ MotionPlanCache::extract_and_append_plan_goal_to_query(
 
       query.append(meta_name + ".link_name", constraint.link_name);
 
-      query.appendRangeInclusive(
-        meta_name + ".target_point_offset.x",
-        NEXUS_MATCH_RANGE(
-          x_offset + constraint.target_point_offset.x, match_tolerance));
-      query.appendRangeInclusive(
-        meta_name + ".target_point_offset.y",
-        NEXUS_MATCH_RANGE(
-          y_offset + constraint.target_point_offset.y, match_tolerance));
-      query.appendRangeInclusive(
-        meta_name + ".target_point_offset.z",
-        NEXUS_MATCH_RANGE(
-          z_offset + constraint.target_point_offset.z, match_tolerance));
+      query_append_range_inclusive_with_tolerance(
+        query, meta_name + ".target_point_offset.x",
+        x_offset + constraint.target_point_offset.x, match_tolerance);
+      query_append_range_inclusive_with_tolerance(
+        query, meta_name + ".target_point_offset.y",
+        y_offset + constraint.target_point_offset.y, match_tolerance);
+      query_append_range_inclusive_with_tolerance(
+        query, meta_name + ".target_point_offset.z",
+        z_offset + constraint.target_point_offset.z, match_tolerance);
     }
   }
 
@@ -588,18 +632,18 @@ MotionPlanCache::extract_and_append_plan_goal_to_query(
       auto final_quat = tf2_quat_goal_offset * tf2_quat_frame_offset;
       final_quat.normalize();
 
-      query.appendRangeInclusive(
-        meta_name + ".target_point_offset.x",
-        NEXUS_MATCH_RANGE(final_quat.getX(), match_tolerance));
-      query.appendRangeInclusive(
-        meta_name + ".target_point_offset.y",
-        NEXUS_MATCH_RANGE(final_quat.getY(), match_tolerance));
-      query.appendRangeInclusive(
-        meta_name + ".target_point_offset.z",
-        NEXUS_MATCH_RANGE(final_quat.getZ(), match_tolerance));
-      query.appendRangeInclusive(
-        meta_name + ".target_point_offset.w",
-        NEXUS_MATCH_RANGE(final_quat.getW(), match_tolerance));
+      query_append_range_inclusive_with_tolerance(
+        query, meta_name + ".target_point_offset.x",
+        final_quat.getX(), match_tolerance);
+      query_append_range_inclusive_with_tolerance(
+        query, meta_name + ".target_point_offset.y",
+        final_quat.getY(), match_tolerance);
+      query_append_range_inclusive_with_tolerance(
+        query, meta_name + ".target_point_offset.z",
+        final_quat.getZ(), match_tolerance);
+      query_append_range_inclusive_with_tolerance(
+        query, meta_name + ".target_point_offset.w",
+        final_quat.getW(), match_tolerance);
     }
   }
 
@@ -665,6 +709,13 @@ MotionPlanCache::extract_and_append_plan_start_to_metadata(
     //   I think if is_diff is on, the joint states will not be populated in all
     //   of our motion plan requests? If this isn't the case we might need to
     //   apply the joint states as offsets as well.
+    //
+    // TODO: Since MoveIt also potentially does another getCurrentState() call
+    //   when planning, there is a chance that the current state in the cache
+    //   differs from the state used in MoveIt's plan.
+    //
+    //   When upstreaming this class to MoveIt, this issue should go away once
+    //   the class is used within the move group's Plan call.
     moveit::core::RobotStatePtr current_state = move_group.getCurrentState();
     if (!current_state)
     {
@@ -763,6 +814,10 @@ MotionPlanCache::extract_and_append_plan_goal_to_metadata(
     {
       orientation_constraints.push_back(orientation_constraint);
     }
+
+    // Also sort for even less cardinality.
+    sort_constraints(
+      joint_constraints, position_constraints, orientation_constraints);
   }
 
   // Joint constraints
@@ -929,7 +984,634 @@ MotionPlanCache::extract_and_append_plan_goal_to_metadata(
   return true;
 }
 
-#undef NEXUS_MATCH_RANGE
+// =============================================================================
+// CARTESIAN PLAN CACHING
+// =============================================================================
+// CARTESIAN PLAN CACHING: TOP LEVEL OPS
+moveit_msgs::srv::GetCartesianPath::Request
+MotionPlanCache::construct_get_cartesian_plan_request(
+  moveit::planning_interface::MoveGroupInterface& move_group,
+  const std::vector<geometry_msgs::msg::Pose>& waypoints,
+  double step, double jump_threshold, bool avoid_collisions)
+{
+  moveit_msgs::srv::GetCartesianPath::Request out;
+
+  // Some of these parameters need us to pull PRIVATE values out of the
+  // move_group elsewhere... Yes, it is very cursed and I hate it.
+  // Fixing it requires fixing it in MoveIt.
+  moveit_msgs::msg::MotionPlanRequest tmp;
+  move_group.constructMotionPlanRequest(tmp);
+
+  out.start_state = std::move(tmp.start_state);
+  out.group_name = std::move(tmp.group_name);
+  out.max_velocity_scaling_factor = tmp.max_velocity_scaling_factor;
+  out.max_acceleration_scaling_factor = tmp.max_acceleration_scaling_factor;
+
+  out.header.frame_id = move_group.getPoseReferenceFrame();
+  out.waypoints = waypoints;
+  out.max_step = step;
+  out.jump_threshold = jump_threshold;
+  out.path_constraints = moveit_msgs::msg::Constraints();
+  out.avoid_collisions = avoid_collisions;
+  out.link_name = move_group.getEndEffectorLink();
+
+  // We were already cursed before, now we are double cursed...
+  // move_group.getNodeHandle() is UNIMPLEMENTED upstream.
+  out.header.stamp = node_->now();
+
+  return out;
+}
+
+std::vector<MessageWithMetadata<moveit_msgs::msg::RobotTrajectory>::ConstPtr>
+MotionPlanCache::fetch_all_matching_cartesian_plans(
+  const moveit::planning_interface::MoveGroupInterface& move_group,
+  const std::string& move_group_namespace,
+  const moveit_msgs::srv::GetCartesianPath::Request& plan_request,
+  double min_fraction,
+  double start_tolerance, double goal_tolerance, bool metadata_only,
+  const std::string& sort_by)
+{
+  auto coll = db_->openCollection<moveit_msgs::msg::RobotTrajectory>(
+    "move_group_cartesian_plan_cache", move_group_namespace);
+
+  Query::Ptr query = coll.createQuery();
+
+  bool start_ok = this->extract_and_append_cartesian_plan_start_to_query(
+    *query, move_group, plan_request, start_tolerance);
+  bool goal_ok = this->extract_and_append_cartesian_plan_goal_to_query(
+    *query, move_group, plan_request, goal_tolerance);
+
+  if (!start_ok || !goal_ok)
+  {
+    RCLCPP_ERROR(
+      node_->get_logger(), "Could not construct cartesian plan query.");
+    return {};
+  }
+
+  query->appendGTE("fraction", min_fraction);
+  return coll.queryList(query, metadata_only, sort_by, true);
+}
+
+MessageWithMetadata<moveit_msgs::msg::RobotTrajectory>::ConstPtr
+MotionPlanCache::fetch_best_matching_cartesian_plan(
+  const moveit::planning_interface::MoveGroupInterface& move_group,
+  const std::string& move_group_namespace,
+  const moveit_msgs::srv::GetCartesianPath::Request& plan_request,
+  double min_fraction,
+  double start_tolerance, double goal_tolerance, bool metadata_only,
+  const std::string& sort_by)
+{
+  // First find all matching, but metadata only.
+  // Then use the ID metadata of the best plan to pull the actual message.
+  auto matching_plans = this->fetch_all_matching_cartesian_plans(
+    move_group, move_group_namespace,
+    plan_request, min_fraction,
+    start_tolerance, goal_tolerance, true, sort_by);
+
+  if (matching_plans.empty())
+  {
+    RCLCPP_INFO(node_->get_logger(), "No matching cartesian plans found.");
+    return nullptr;
+  }
+
+  auto coll = db_->openCollection<moveit_msgs::msg::RobotTrajectory>(
+    "move_group_cartesian_plan_cache", move_group_namespace);
+
+  // Best plan is at first index, since the lookup query was sorted by
+  // execution_time.
+  int best_plan_id = matching_plans.at(0)->lookupInt("id");
+  Query::Ptr best_query = coll.createQuery();
+  best_query->append("id", best_plan_id);
+
+  return coll.findOne(best_query, metadata_only);
+}
+
+bool
+MotionPlanCache::put_cartesian_plan(
+  const moveit::planning_interface::MoveGroupInterface& move_group,
+  const std::string& move_group_namespace,
+  const moveit_msgs::srv::GetCartesianPath::Request& plan_request,
+  const moveit_msgs::msg::RobotTrajectory& plan,
+  double execution_time_s,
+  double planning_time_s,
+  double fraction,
+  bool delete_worse_plans)
+{
+  // Check pre-conditions
+  if (!plan.multi_dof_joint_trajectory.points.empty())
+  {
+    RCLCPP_ERROR(
+      node_->get_logger(),
+      "Skipping cartesian plan insert: "
+      "Multi-DOF trajectory plans are not supported.");
+    return false;
+  }
+  if (plan_request.header.frame_id.empty() ||
+    plan.joint_trajectory.header.frame_id.empty())
+  {
+    RCLCPP_ERROR(
+      node_->get_logger(),
+      "Skipping cartesian plan insert: Frame IDs cannot be empty.");
+    return false;
+  }
+
+  auto coll = db_->openCollection<moveit_msgs::msg::RobotTrajectory>(
+    "move_group_cartesian_plan_cache", move_group_namespace);
+
+  // Pull out plans "exactly" keyed by request in cache.
+  Query::Ptr exact_query = coll.createQuery();
+
+  bool start_query_ok = this->extract_and_append_cartesian_plan_start_to_query(
+    *exact_query, move_group, plan_request, 0);
+  bool goal_query_ok = this->extract_and_append_cartesian_plan_goal_to_query(
+    *exact_query, move_group, plan_request, 0);
+  exact_query->append("fraction", fraction);
+
+  if (!start_query_ok || !goal_query_ok)
+  {
+    RCLCPP_ERROR(
+      node_->get_logger(),
+      "Skipping cartesian plan insert: Could not construct lookup query.");
+    return false;
+  }
+
+  auto exact_matches = coll.queryList(
+    exact_query, /* metadata_only */ true, /* sort_by */ "execution_time_s");
+  double best_execution_time = std::numeric_limits<double>::infinity();
+  if (!exact_matches.empty())
+  {
+    best_execution_time = exact_matches.at(0)->lookupDouble("execution_time_s");
+
+    if (delete_worse_plans)
+    {
+      for (auto& match : exact_matches)
+      {
+        double match_execution_time_s = match->lookupDouble("execution_time_s");
+        if (execution_time_s < match_execution_time_s)
+        {
+          int delete_id = match->lookupInt("id");
+          RCLCPP_INFO(
+            node_->get_logger(),
+            "Overwriting cartesian plan (id: %d): "
+            "execution_time (%es) > new plan's execution_time (%es)",
+            delete_id, match_execution_time_s, execution_time_s);
+
+          Query::Ptr delete_query = coll.createQuery();
+          delete_query->append("id", delete_id);
+          coll.removeMessages(delete_query);
+        }
+      }
+    }
+  }
+
+  // Insert if candidate is best seen.
+  if (execution_time_s < best_execution_time)
+  {
+    Metadata::Ptr insert_metadata = coll.createMetadata();
+
+    bool start_meta_ok =
+      this->extract_and_append_cartesian_plan_start_to_metadata(
+      *insert_metadata, move_group, plan_request);
+    bool goal_meta_ok =
+      this->extract_and_append_cartesian_plan_goal_to_metadata(
+      *insert_metadata, move_group, plan_request);
+    insert_metadata->append("execution_time_s", execution_time_s);
+    insert_metadata->append("planning_time_s", planning_time_s);
+    insert_metadata->append("fraction", fraction);
+
+    if (!start_meta_ok || !goal_meta_ok)
+    {
+      RCLCPP_ERROR(
+        node_->get_logger(),
+        "Skipping cartesian plan insert: Could not construct insert metadata.");
+      return false;
+    }
+
+    RCLCPP_INFO(
+      node_->get_logger(),
+      "Inserting cartesian plan: New plan execution_time (%es) "
+      "is better than best plan's execution_time (%es) at fraction (%es)",
+      execution_time_s, best_execution_time, fraction);
+
+    coll.insert(plan, insert_metadata);
+    return true;
+  }
+
+  RCLCPP_INFO(
+    node_->get_logger(),
+    "Skipping cartesian plan insert: New plan execution_time (%es) "
+    "is worse than best plan's execution_time (%es) at fraction (%es)",
+    execution_time_s, best_execution_time, fraction);
+  return false;
+}
+
+// // CARTESIAN PLAN CACHING: QUERY CONSTRUCTION
+bool
+MotionPlanCache::extract_and_append_cartesian_plan_start_to_query(
+  Query& query,
+  const moveit::planning_interface::MoveGroupInterface& move_group,
+  const moveit_msgs::srv::GetCartesianPath::Request& plan_request,
+  double match_tolerance)
+{
+  match_tolerance += exact_match_precision_;
+
+  // Make ignored members explicit
+  if (!plan_request.start_state.multi_dof_joint_state.joint_names.empty())
+  {
+    RCLCPP_WARN(
+      node_->get_logger(),
+      "Ignoring start_state.multi_dof_joint_states: Not supported.");
+  }
+  if (!plan_request.start_state.attached_collision_objects.empty())
+  {
+    RCLCPP_WARN(
+      node_->get_logger(),
+      "Ignoring start_state.attached_collision_objects: Not supported.");
+  }
+
+  // auto original = *metadata;  // Copy not supported.
+
+  query.append("group_name", plan_request.group_name);
+
+  // Joint state
+  //   Only accounts for joint_state position. Ignores velocity and effort.
+  if (plan_request.start_state.is_diff)
+  {
+    // If plan request states that the start_state is_diff, then we need to get
+    // the current state from the move_group.
+
+    // NOTE: methyldragon -
+    //   I think if is_diff is on, the joint states will not be populated in all
+    //   of our motion plan requests? If this isn't the case we might need to
+    //   apply the joint states as offsets as well.
+    //
+    // TODO: Since MoveIt also potentially does another getCurrentState() call
+    //   when planning, there is a chance that the current state in the cache
+    //   differs from the state used in MoveIt's plan.
+    //
+    //   When upstreaming this class to MoveIt, this issue should go away once
+    //   the class is used within the move group's Plan call.
+    moveit::core::RobotStatePtr current_state = move_group.getCurrentState();
+    if (!current_state)
+    {
+      RCLCPP_WARN(
+        node_->get_logger(),
+        "Skipping start metadata append: Could not get robot state.");
+      // *metadata = original;  // Undo our changes.  // Copy not supported
+      return false;
+    }
+
+    moveit_msgs::msg::RobotState current_state_msg;
+    robotStateToRobotStateMsg(*current_state, current_state_msg);
+
+    for (size_t i = 0; i < current_state_msg.joint_state.name.size(); i++)
+    {
+      query.append(
+        "start_state.joint_state.name_" + std::to_string(i),
+        current_state_msg.joint_state.name.at(i));
+      query_append_range_inclusive_with_tolerance(
+        query, "start_state.joint_state.position_" + std::to_string(i),
+        current_state_msg.joint_state.position.at(i), match_tolerance);
+    }
+  }
+  else
+  {
+    for (
+      size_t i = 0; i < plan_request.start_state.joint_state.name.size(); i++
+    )
+    {
+      query.append(
+        "start_state.joint_state.name_" + std::to_string(i),
+        plan_request.start_state.joint_state.name.at(i));
+      query_append_range_inclusive_with_tolerance(
+        query, "start_state.joint_state.position_" + std::to_string(i),
+        plan_request.start_state.joint_state.position.at(i), match_tolerance);
+    }
+  }
+
+  return true;
+}
+
+bool
+MotionPlanCache::extract_and_append_cartesian_plan_goal_to_query(
+  Query& query,
+  const moveit::planning_interface::MoveGroupInterface& move_group,
+  const moveit_msgs::srv::GetCartesianPath::Request& plan_request,
+  double match_tolerance)
+{
+  match_tolerance += exact_match_precision_;
+
+  // Make ignored members explicit
+  if (!plan_request.path_constraints.joint_constraints.empty() ||
+    !plan_request.path_constraints.position_constraints.empty() ||
+    !plan_request.path_constraints.orientation_constraints.empty() ||
+    !plan_request.path_constraints.visibility_constraints.empty())
+  {
+    RCLCPP_WARN(
+      node_->get_logger(), "Ignoring path_constraints: Not supported.");
+  }
+  if (plan_request.avoid_collisions)
+  {
+    RCLCPP_WARN(node_->get_logger(),
+      "Ignoring avoid_collisions: Not supported.");
+  }
+
+  // auto original = *metadata;  // Copy not supported.
+
+  query_append_range_inclusive_with_tolerance(
+    query, "max_velocity_scaling_factor",
+    plan_request.max_velocity_scaling_factor, match_tolerance);
+  query_append_range_inclusive_with_tolerance(
+    query, "max_acceleration_scaling_factor",
+    plan_request.max_acceleration_scaling_factor, match_tolerance);
+  query_append_range_inclusive_with_tolerance(
+    query, "max_step", plan_request.max_step, match_tolerance);
+  query_append_range_inclusive_with_tolerance(
+    query, "jump_threshold", plan_request.jump_threshold, match_tolerance);
+
+  // Waypoints
+  // Restating them in terms of the robot model frame (usually base_link)
+  std::string base_frame = move_group.getRobotModel()->getModelFrame();
+
+  // Compute offsets.
+  double x_offset = 0;
+  double y_offset = 0;
+  double z_offset = 0;
+
+  geometry_msgs::msg::Quaternion quat_offset;
+  quat_offset.x = 0;
+  quat_offset.y = 0;
+  quat_offset.z = 0;
+  quat_offset.w = 1;
+
+  if (base_frame != plan_request.header.frame_id)
+  {
+    try
+    {
+      auto transform = tf_buffer_->lookupTransform(
+        plan_request.header.frame_id, base_frame, tf2::TimePointZero);
+
+      x_offset = transform.transform.translation.x;
+      y_offset = transform.transform.translation.y;
+      z_offset = transform.transform.translation.z;
+      quat_offset = transform.transform.rotation;
+    }
+    catch (tf2::TransformException& ex)
+    {
+      RCLCPP_WARN(
+        node_->get_logger(),
+        "Skipping goal metadata append: "
+        "Could not get goal transform for %s to %s: %s",
+        base_frame.c_str(), plan_request.header.frame_id.c_str(),
+        ex.what());
+
+      // (Can't. Copy not supported.)
+      // *metadata = original;  // Undo our changes.
+      return false;
+    }
+  }
+
+  tf2::Quaternion tf2_quat_frame_offset(
+    quat_offset.x, quat_offset.y, quat_offset.z, quat_offset.w);
+  tf2_quat_frame_offset.normalize();
+
+  size_t waypoint_idx = 0;
+  for (auto& waypoint : plan_request.waypoints)
+  {
+    std::string meta_name = "waypoints_" + std::to_string(waypoint_idx++);
+
+    // Apply offsets
+    // Position
+    query_append_range_inclusive_with_tolerance(
+      query, meta_name + ".position.x",
+      x_offset + waypoint.position.x, match_tolerance);
+    query_append_range_inclusive_with_tolerance(
+      query, meta_name + ".position.y",
+      y_offset + waypoint.position.y, match_tolerance);
+    query_append_range_inclusive_with_tolerance(
+      query, meta_name + ".position.z",
+      z_offset + waypoint.position.z, match_tolerance);
+
+    // Orientation
+    tf2::Quaternion tf2_quat_goal_offset(
+      waypoint.orientation.x,
+      waypoint.orientation.y,
+      waypoint.orientation.z,
+      waypoint.orientation.w);
+    tf2_quat_goal_offset.normalize();
+
+    auto final_quat = tf2_quat_goal_offset * tf2_quat_frame_offset;
+    final_quat.normalize();
+
+    query_append_range_inclusive_with_tolerance(
+      query, meta_name + ".orientation.x", final_quat.getX(), match_tolerance);
+    query_append_range_inclusive_with_tolerance(
+      query, meta_name + ".orientation.y", final_quat.getY(), match_tolerance);
+    query_append_range_inclusive_with_tolerance(
+      query, meta_name + ".orientation.z", final_quat.getZ(), match_tolerance);
+    query_append_range_inclusive_with_tolerance(
+      query, meta_name + ".orientation.w", final_quat.getW(), match_tolerance);
+  }
+
+  query.append("link_name", plan_request.link_name);
+  query.append("header.frame_id", base_frame);
+
+  return true;
+}
+
+// CARTESIAN PLAN CACHING: METADATA CONSTRUCTION
+bool
+MotionPlanCache::extract_and_append_cartesian_plan_start_to_metadata(
+  Metadata& metadata,
+  const moveit::planning_interface::MoveGroupInterface& move_group,
+  const moveit_msgs::srv::GetCartesianPath::Request& plan_request)
+{
+  // Make ignored members explicit
+  if (!plan_request.start_state.multi_dof_joint_state.joint_names.empty())
+  {
+    RCLCPP_WARN(
+      node_->get_logger(),
+      "Ignoring start_state.multi_dof_joint_states: Not supported.");
+  }
+  if (!plan_request.start_state.attached_collision_objects.empty())
+  {
+    RCLCPP_WARN(
+      node_->get_logger(),
+      "Ignoring start_state.attached_collision_objects: Not supported.");
+  }
+
+  // auto original = *metadata;  // Copy not supported.
+
+  metadata.append("group_name", plan_request.group_name);
+
+  // Joint state
+  //   Only accounts for joint_state position. Ignores velocity and effort.
+  if (plan_request.start_state.is_diff)
+  {
+    // If plan request states that the start_state is_diff, then we need to get
+    // the current state from the move_group.
+
+    // NOTE: methyldragon -
+    //   I think if is_diff is on, the joint states will not be populated in all
+    //   of our motion plan requests? If this isn't the case we might need to
+    //   apply the joint states as offsets as well.
+    //
+    // TODO: Since MoveIt also potentially does another getCurrentState() call
+    //   when planning, there is a chance that the current state in the cache
+    //   differs from the state used in MoveIt's plan.
+    //
+    //   When upstreaming this class to MoveIt, this issue should go away once
+    //   the class is used within the move group's Plan call.
+    moveit::core::RobotStatePtr current_state = move_group.getCurrentState();
+    if (!current_state)
+    {
+      RCLCPP_WARN(
+        node_->get_logger(),
+        "Skipping start metadata append: Could not get robot state.");
+      // *metadata = original;  // Undo our changes.  // Copy not supported
+      return false;
+    }
+
+    moveit_msgs::msg::RobotState current_state_msg;
+    robotStateToRobotStateMsg(*current_state, current_state_msg);
+
+    for (size_t i = 0; i < current_state_msg.joint_state.name.size(); i++)
+    {
+      metadata.append(
+        "start_state.joint_state.name_" + std::to_string(i),
+        current_state_msg.joint_state.name.at(i));
+      metadata.append(
+        "start_state.joint_state.position_" + std::to_string(i),
+        current_state_msg.joint_state.position.at(i));
+    }
+  }
+  else
+  {
+    for (
+      size_t i = 0; i < plan_request.start_state.joint_state.name.size(); i++
+    )
+    {
+      metadata.append(
+        "start_state.joint_state.name_" + std::to_string(i),
+        plan_request.start_state.joint_state.name.at(i));
+      metadata.append(
+        "start_state.joint_state.position_" + std::to_string(i),
+        plan_request.start_state.joint_state.position.at(i));
+    }
+  }
+
+  return true;
+}
+
+bool
+MotionPlanCache::extract_and_append_cartesian_plan_goal_to_metadata(
+  Metadata& metadata,
+  const moveit::planning_interface::MoveGroupInterface& move_group,
+  const moveit_msgs::srv::GetCartesianPath::Request& plan_request)
+{
+  // Make ignored members explicit
+  if (!plan_request.path_constraints.joint_constraints.empty() ||
+    !plan_request.path_constraints.position_constraints.empty() ||
+    !plan_request.path_constraints.orientation_constraints.empty() ||
+    !plan_request.path_constraints.visibility_constraints.empty())
+  {
+    RCLCPP_WARN(
+      node_->get_logger(), "Ignoring path_constraints: Not supported.");
+  }
+  if (plan_request.avoid_collisions)
+  {
+    RCLCPP_WARN(node_->get_logger(),
+      "Ignoring avoid_collisions: Not supported.");
+  }
+
+  // auto original = *metadata;  // Copy not supported.
+
+  metadata.append("max_velocity_scaling_factor",
+    plan_request.max_velocity_scaling_factor);
+  metadata.append("max_acceleration_scaling_factor",
+    plan_request.max_acceleration_scaling_factor);
+  metadata.append("max_step", plan_request.max_step);
+  metadata.append("jump_threshold", plan_request.jump_threshold);
+
+  // Waypoints
+  // Restating them in terms of the robot model frame (usually base_link)
+  std::string base_frame = move_group.getRobotModel()->getModelFrame();
+
+  // Compute offsets.
+  double x_offset = 0;
+  double y_offset = 0;
+  double z_offset = 0;
+
+  geometry_msgs::msg::Quaternion quat_offset;
+  quat_offset.x = 0;
+  quat_offset.y = 0;
+  quat_offset.z = 0;
+  quat_offset.w = 1;
+
+  if (base_frame != plan_request.header.frame_id)
+  {
+    try
+    {
+      auto transform = tf_buffer_->lookupTransform(
+        plan_request.header.frame_id, base_frame, tf2::TimePointZero);
+
+      x_offset = transform.transform.translation.x;
+      y_offset = transform.transform.translation.y;
+      z_offset = transform.transform.translation.z;
+      quat_offset = transform.transform.rotation;
+    }
+    catch (tf2::TransformException& ex)
+    {
+      RCLCPP_WARN(
+        node_->get_logger(),
+        "Skipping goal metadata append: "
+        "Could not get goal transform for %s to %s: %s",
+        base_frame.c_str(), plan_request.header.frame_id.c_str(),
+        ex.what());
+
+      // (Can't. Copy not supported.)
+      // *metadata = original;  // Undo our changes.
+      return false;
+    }
+  }
+
+  tf2::Quaternion tf2_quat_frame_offset(
+    quat_offset.x, quat_offset.y, quat_offset.z, quat_offset.w);
+  tf2_quat_frame_offset.normalize();
+
+  size_t waypoint_idx = 0;
+  for (auto& waypoint : plan_request.waypoints)
+  {
+    std::string meta_name = "waypoints_" + std::to_string(waypoint_idx++);
+
+    // Apply offsets
+    // Position
+    metadata.append(meta_name + ".position.x", x_offset + waypoint.position.x);
+    metadata.append(meta_name + ".position.y", y_offset + waypoint.position.y);
+    metadata.append(meta_name + ".position.z", z_offset + waypoint.position.z);
+
+    // Orientation
+    tf2::Quaternion tf2_quat_goal_offset(
+      waypoint.orientation.x,
+      waypoint.orientation.y,
+      waypoint.orientation.z,
+      waypoint.orientation.w);
+    tf2_quat_goal_offset.normalize();
+
+    auto final_quat = tf2_quat_goal_offset * tf2_quat_frame_offset;
+    final_quat.normalize();
+
+    metadata.append(meta_name + ".orientation.x", final_quat.getX());
+    metadata.append(meta_name + ".orientation.y", final_quat.getY());
+    metadata.append(meta_name + ".orientation.z", final_quat.getZ());
+    metadata.append(meta_name + ".orientation.w", final_quat.getW());
+  }
+
+  metadata.append("link_name", plan_request.link_name);
+  metadata.append("header.frame_id", base_frame);
+
+  return true;
+}
 
 }  // namespace motion_planner
 }  // namespace nexus

--- a/nexus_motion_planner/src/motion_plan_cache.cpp
+++ b/nexus_motion_planner/src/motion_plan_cache.cpp
@@ -1,3 +1,17 @@
+// Copyright 2022 Johnson & Johnson
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <memory>
 #include <vector>
 

--- a/nexus_motion_planner/src/motion_plan_cache.cpp
+++ b/nexus_motion_planner/src/motion_plan_cache.cpp
@@ -83,11 +83,6 @@ MotionPlanCache::MotionPlanCache(const rclcpp::Node::SharedPtr& node)
     std::make_unique<tf2_ros::Buffer>(node_->get_clock());
   tf_listener_ =
     std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
-
-  // If the `warehouse_plugin` parameter isn't set, defaults to warehouse_ros'
-  // default.
-  warehouse_ros::DatabaseLoader loader(node_);
-  db_ = loader.loadDatabase();
 }
 
 bool MotionPlanCache::init(
@@ -97,6 +92,11 @@ bool MotionPlanCache::init(
     node_->get_logger(),
     "Opening motion plan cache database at: %s (Port: %d, Precision: %f)",
     db_path.c_str(), db_port, exact_match_precision);
+
+  // If the `warehouse_plugin` parameter isn't set, defaults to warehouse_ros'
+  // default.
+  warehouse_ros::DatabaseLoader loader(node_);
+  db_ = loader.loadDatabase();
 
   exact_match_precision_ = exact_match_precision;
   db_->setParams(db_path, db_port);

--- a/nexus_motion_planner/src/motion_plan_cache.cpp
+++ b/nexus_motion_planner/src/motion_plan_cache.cpp
@@ -54,7 +54,7 @@ void MotionPlanCache::init(
 
 // TOP LEVEL OPS ===============================================================
 std::vector<MessageWithMetadata<moveit_msgs::msg::RobotTrajectory>::ConstPtr>
-MotionPlanCache::fetchAllMatchingPlans(
+MotionPlanCache::fetch_all_matching_plans(
   const moveit::planning_interface::MoveGroupInterface& move_group,
   const std::string& move_group_namespace,
   const moveit_msgs::msg::MotionPlanRequest& plan_request,
@@ -65,9 +65,9 @@ MotionPlanCache::fetchAllMatchingPlans(
 
   Query::Ptr query = coll.createQuery();
 
-  bool start_ok = this->extractAndAppendStartToQuery(
+  bool start_ok = this->extract_and_append_start_to_query(
     *query, move_group, plan_request, start_tolerance);
-  bool goal_ok = this->extractAndAppendGoalToQuery(
+  bool goal_ok = this->extract_and_append_goal_to_query(
     *query, move_group, plan_request, goal_tolerance);
 
   if (!start_ok || !goal_ok)
@@ -81,7 +81,7 @@ MotionPlanCache::fetchAllMatchingPlans(
 }
 
 MessageWithMetadata<moveit_msgs::msg::RobotTrajectory>::ConstPtr
-MotionPlanCache::fetchBestMatchingPlan(
+MotionPlanCache::fetch_best_matching_plan(
   const moveit::planning_interface::MoveGroupInterface& move_group,
   const std::string& move_group_namespace,
   const moveit_msgs::msg::MotionPlanRequest& plan_request,
@@ -89,7 +89,7 @@ MotionPlanCache::fetchBestMatchingPlan(
 {
   // First find all matching, but metadata only.
   // Then use the ID metadata of the best plan to pull the actual message.
-  auto matching_plans = this->fetchAllMatchingPlans(
+  auto matching_plans = this->fetch_all_matching_plans(
     move_group, move_group_namespace,
     plan_request, start_tolerance, goal_tolerance,
     true);
@@ -113,7 +113,7 @@ MotionPlanCache::fetchBestMatchingPlan(
 }
 
 bool
-MotionPlanCache::putPlan(
+MotionPlanCache::put_plan(
   const moveit::planning_interface::MoveGroupInterface& move_group,
   const std::string& move_group_namespace,
   const moveit_msgs::msg::MotionPlanRequest& plan_request,
@@ -155,10 +155,10 @@ MotionPlanCache::putPlan(
   // overwrite.
   Query::Ptr exact_query = coll.createQuery();
 
-  bool start_query_ok = this->extractAndAppendStartToQuery(
+  bool start_query_ok = this->extract_and_append_start_to_query(
     *exact_query, move_group,
     plan_request, exact_match_precision_);
-  bool goal_query_ok = this->extractAndAppendGoalToQuery(
+  bool goal_query_ok = this->extract_and_append_goal_to_query(
     *exact_query, move_group,
     plan_request, exact_match_precision_);
 
@@ -208,9 +208,9 @@ MotionPlanCache::putPlan(
   {
     Metadata::Ptr insert_metadata = coll.createMetadata();
 
-    bool start_meta_ok = this->extractAndAppendStartToMetadata(
+    bool start_meta_ok = this->extract_and_append_start_to_metadata(
       *insert_metadata, move_group, plan_request);
-    bool goal_meta_ok = this->extractAndAppendGoalToMetadata(
+    bool goal_meta_ok = this->extract_and_append_goal_to_metadata(
       *insert_metadata, move_group, plan_request);
     insert_metadata->append("execution_time_s", execution_time_s);
 
@@ -242,7 +242,7 @@ MotionPlanCache::putPlan(
 
 // QUERY CONSTRUCTION ==========================================================
 bool
-MotionPlanCache::extractAndAppendStartToQuery(
+MotionPlanCache::extract_and_append_start_to_query(
   Query& query,
   const moveit::planning_interface::MoveGroupInterface& move_group,
   const moveit_msgs::msg::MotionPlanRequest& plan_request,
@@ -302,7 +302,7 @@ MotionPlanCache::extractAndAppendStartToQuery(
     // NOTE: methyldragon -
     //   I think if is_diff is on, the joint states will not be populated in all
     //   of our motion plan requests? If this isn't the case we might need to
-    //   apply the joint states after as well.
+    //   apply the joint states as offsets as well.
     moveit::core::RobotStatePtr current_state = move_group.getCurrentState();
     if (!current_state)
     {
@@ -348,7 +348,7 @@ MotionPlanCache::extractAndAppendStartToQuery(
 }
 
 bool
-MotionPlanCache::extractAndAppendGoalToQuery(
+MotionPlanCache::extract_and_append_goal_to_query(
   Query& query,
   const moveit::planning_interface::MoveGroupInterface& /* move_group */,
   const moveit_msgs::msg::MotionPlanRequest& plan_request,
@@ -591,7 +591,7 @@ MotionPlanCache::extractAndAppendGoalToQuery(
 
 // METADATA CONSTRUCTION =======================================================
 bool
-MotionPlanCache::extractAndAppendStartToMetadata(
+MotionPlanCache::extract_and_append_start_to_metadata(
   Metadata& metadata,
   const moveit::planning_interface::MoveGroupInterface& move_group,
   const moveit_msgs::msg::MotionPlanRequest& plan_request)
@@ -647,7 +647,7 @@ MotionPlanCache::extractAndAppendStartToMetadata(
     // NOTE: methyldragon -
     //   I think if is_diff is on, the joint states will not be populated in all
     //   of our motion plan requests? If this isn't the case we might need to
-    //   apply the joint states after as well.
+    //   apply the joint states as offsets as well.
     moveit::core::RobotStatePtr current_state = move_group.getCurrentState();
     if (!current_state)
     {
@@ -690,7 +690,7 @@ MotionPlanCache::extractAndAppendStartToMetadata(
 }
 
 bool
-MotionPlanCache::extractAndAppendGoalToMetadata(
+MotionPlanCache::extract_and_append_goal_to_metadata(
   Metadata& metadata,
   const moveit::planning_interface::MoveGroupInterface& /* move_group */,
   const moveit_msgs::msg::MotionPlanRequest& plan_request)

--- a/nexus_motion_planner/src/motion_plan_cache.cpp
+++ b/nexus_motion_planner/src/motion_plan_cache.cpp
@@ -119,6 +119,7 @@ MotionPlanCache::put_plan(
   const moveit_msgs::msg::MotionPlanRequest& plan_request,
   const moveit_msgs::msg::RobotTrajectory& plan,
   double execution_time_s,
+  double planning_time_s,
   bool overwrite)
 {
   // Check pre-conditions
@@ -213,6 +214,7 @@ MotionPlanCache::put_plan(
     bool goal_meta_ok = this->extract_and_append_goal_to_metadata(
       *insert_metadata, move_group, plan_request);
     insert_metadata->append("execution_time_s", execution_time_s);
+    insert_metadata->append("planning_time_s", planning_time_s);
 
     if (!start_meta_ok || !goal_meta_ok)
     {

--- a/nexus_motion_planner/src/motion_plan_cache.hpp
+++ b/nexus_motion_planner/src/motion_plan_cache.hpp
@@ -50,7 +50,15 @@ namespace motion_planner {
  * how long they took to execute. This allows for the lookup and reuse of the
  * best performing plans found so far.
  *
- * WARNING: This cache does NOT yet support collision detection!
+ * WARNING:
+ *   This cache does NOT support collision detection!
+ *   Plans will be put into and fetched from the cache IGNORING collision.
+ *   If your planning scene is expected to change between cache lookups, do NOT
+ *   use this cache, fetched plans are likely to result in collision then.
+ *
+ *   To handle collisions this class will need to hash the planning scene world
+ *   msg (after zeroing out std_msgs/Header timestamps and sequences) and do an
+ *   appropriate lookup.
  *
  * Relevant ROS Parameters:
  *   - `warehouse_plugin`: What database to use

--- a/nexus_motion_planner/src/motion_plan_cache.hpp
+++ b/nexus_motion_planner/src/motion_plan_cache.hpp
@@ -1,0 +1,137 @@
+#ifndef SRC__MOTION_PLAN_CACHE_HPP
+#define SRC__MOTION_PLAN_CACHE_HPP
+
+#include <chrono>
+#include <memory>
+#include <optional>
+
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_lifecycle/lifecycle_node.hpp>
+
+#include <warehouse_ros/database_loader.h>
+
+// TF2
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
+
+// ROS2 Messages
+#include <geometry_msgs/msg/pose.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <lifecycle_msgs/msg/state.hpp>
+
+// moveit modules
+#include <moveit/move_group_interface/move_group_interface.h>
+
+// NEXUS messages
+#include <nexus_endpoints.hpp>
+
+namespace nexus {
+namespace motion_planner {
+
+/**
+ * Cache manager for the Nexus motion planner.
+ *
+ * This manager facilitates cache management for MoveIt 2's `MoveGroupInterface`
+ * by using `warehouse_ros` to manage a database of executed motion plans, and
+ * how long they took to execute. This allows for the lookup and reuse of the
+ * best performing plans found so far.
+ *
+ * Relevant ROS Parameters:
+ *   - `warehouse_plugin`: What database to use
+ *   - `warehouse_host`: Where the database should be created
+ *   - `warehouse_port`: The port used for the database
+ *
+ * Motion plans are stored in the `move_group_plan_cache` database within the
+ * database file, with plans for each move group stored in a collection named
+ * after the relevant move group's name.
+ *
+ * For example, the "my_move_group" move group will have its cache stored in
+ * `move_group_plan_cache@my_move_group`
+ *
+ * Motion plans are keyed on:
+ *   - Plan Start: robot joint state
+ *   - Plan Goal (either of):
+ *     - Final pose (wrt. `planning_frame` (usually `base_link`))
+ *     - Final robot joint states
+ *
+ * Motion plans may be looked up with some tolerance.
+ */
+class MotionPlanCache
+{
+public:
+  // We explicitly need a Node::SharedPtr because warehouse_ros ONLY supports
+  // it...
+  explicit MotionPlanCache(const rclcpp::Node::SharedPtr& node);
+
+  void init(
+    const std::string& db_path = ":memory:",
+    uint32_t db_port = 0,
+    double exact_match_precision = 0.00001);
+
+  // TOP LEVEL OPS =============================================================
+  std::vector<
+    warehouse_ros::MessageWithMetadata<
+      moveit_msgs::msg::RobotTrajectory
+    >::ConstPtr
+  >
+  fetchAllMatchingPlans(
+    const moveit::planning_interface::MoveGroupInterface& move_group,
+    const std::string& move_group_namespace,
+    const moveit_msgs::msg::MotionPlanRequest& plan_request,
+    double start_tolerance, double goal_tolerance, bool metadata_only = false);
+
+  warehouse_ros::MessageWithMetadata<
+    moveit_msgs::msg::RobotTrajectory
+  >::ConstPtr
+  fetchBestMatchingPlan(
+    const moveit::planning_interface::MoveGroupInterface& move_group,
+    const std::string& move_group_namespace,
+    const moveit_msgs::msg::MotionPlanRequest& plan_request,
+    double start_tolerance, double goal_tolerance, bool metadata_only = false);
+
+  bool putPlan(
+    const moveit::planning_interface::MoveGroupInterface& move_group,
+    const std::string& move_group_namespace,
+    const moveit_msgs::msg::MotionPlanRequest& plan_request,
+    const moveit_msgs::msg::RobotTrajectory& plan,
+    double execution_time_s,
+    bool overwrite = true);
+
+  // QUERY CONSTRUCTION ========================================================
+  bool extractAndAppendStartToQuery(
+    warehouse_ros::Query& query,
+    const moveit::planning_interface::MoveGroupInterface& move_group,
+    const moveit_msgs::msg::MotionPlanRequest& plan_request,
+    double match_tolerance);
+
+  bool extractAndAppendGoalToQuery(
+    warehouse_ros::Query& query,
+    const moveit::planning_interface::MoveGroupInterface& move_group,
+    const moveit_msgs::msg::MotionPlanRequest& plan_request,
+    double match_tolerance);
+
+  // METADATA CONSTRUCTION =====================================================
+  bool extractAndAppendStartToMetadata(
+    warehouse_ros::Metadata& metadata,
+    const moveit::planning_interface::MoveGroupInterface& move_group,
+    const moveit_msgs::msg::MotionPlanRequest& plan_request);
+
+  bool extractAndAppendGoalToMetadata(
+    warehouse_ros::Metadata& metadata,
+    const moveit::planning_interface::MoveGroupInterface& move_group,
+    const moveit_msgs::msg::MotionPlanRequest& plan_request);
+
+private:
+  rclcpp::Node::SharedPtr node_;
+  warehouse_ros::DatabaseConnection::Ptr db_;
+
+  double exact_match_precision_ = 0;
+
+  std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
+};
+
+}  // namespace planning_interface
+}  // namespace moveit
+
+#endif // SRC__MOTION_PLAN_CACHE_HPP

--- a/nexus_motion_planner/src/motion_plan_cache.hpp
+++ b/nexus_motion_planner/src/motion_plan_cache.hpp
@@ -95,6 +95,7 @@ public:
     const moveit_msgs::msg::MotionPlanRequest& plan_request,
     const moveit_msgs::msg::RobotTrajectory& plan,
     double execution_time_s,
+    double planning_time_s,
     bool overwrite = true);
 
   // QUERY CONSTRUCTION ========================================================

--- a/nexus_motion_planner/src/motion_plan_cache.hpp
+++ b/nexus_motion_planner/src/motion_plan_cache.hpp
@@ -35,9 +35,7 @@
 
 // moveit modules
 #include <moveit/move_group_interface/move_group_interface.h>
-
-// NEXUS messages
-#include <nexus_endpoints.hpp>
+#include <moveit_msgs/srv/get_cartesian_path.hpp>
 
 namespace nexus {
 namespace motion_planner {
@@ -87,15 +85,22 @@ public:
   // it...
   explicit MotionPlanCache(const rclcpp::Node::SharedPtr& node);
 
-  void init(
+  bool init(
     const std::string& db_path = ":memory:",
     uint32_t db_port = 0,
     double exact_match_precision = 1e-6);
+
+  unsigned count_plans(const std::string& move_group_namespace);
+
+  unsigned count_cartesian_plans(const std::string& move_group_namespace);
 
   // ===========================================================================
   // MOTION PLAN CACHING
   // ===========================================================================
   // TOP LEVEL OPS
+
+  // Fetches all plans that fit within the requested tolerances for start and
+  // goal conditions, returning them as a vector, sorted by some db column.
   std::vector<
     warehouse_ros::MessageWithMetadata<
       moveit_msgs::msg::RobotTrajectory
@@ -105,8 +110,13 @@ public:
     const moveit::planning_interface::MoveGroupInterface& move_group,
     const std::string& move_group_namespace,
     const moveit_msgs::msg::MotionPlanRequest& plan_request,
-    double start_tolerance, double goal_tolerance, bool metadata_only = false);
+    double start_tolerance,
+    double goal_tolerance,
+    bool metadata_only = false,
+    const std::string& sort_by = "execution_time_s");
 
+  // Fetches the best plan that fits within the requested tolerances for start
+  // and goal conditions, by some db column.
   warehouse_ros::MessageWithMetadata<
     moveit_msgs::msg::RobotTrajectory
   >::ConstPtr
@@ -114,8 +124,18 @@ public:
     const moveit::planning_interface::MoveGroupInterface& move_group,
     const std::string& move_group_namespace,
     const moveit_msgs::msg::MotionPlanRequest& plan_request,
-    double start_tolerance, double goal_tolerance, bool metadata_only = false);
+    double start_tolerance,
+    double goal_tolerance,
+    bool metadata_only = false,
+    const std::string& sort_by = "execution_time_s");
 
+  // Put a plan into the database if it is the best matching plan seen so far.
+  //
+  // Plans are matched based off their start and goal states.
+  // And are considered "better" if they have a smaller planned execution time
+  // than matching plans.
+  //
+  // Optionally deletes all worse plans by default to prune the cache.
   bool put_plan(
     const moveit::planning_interface::MoveGroupInterface& move_group,
     const std::string& move_group_namespace,
@@ -123,7 +143,7 @@ public:
     const moveit_msgs::msg::RobotTrajectory& plan,
     double execution_time_s,
     double planning_time_s,
-    bool overwrite = true);
+    bool delete_worse_plans = true);
 
   // QUERY CONSTRUCTION
   bool extract_and_append_plan_start_to_query(
@@ -148,6 +168,96 @@ public:
     warehouse_ros::Metadata& metadata,
     const moveit::planning_interface::MoveGroupInterface& move_group,
     const moveit_msgs::msg::MotionPlanRequest& plan_request);
+
+  // ===========================================================================
+  // CARTESIAN PLAN CACHING
+  // ===========================================================================
+  // TOP LEVEL OPS
+
+  // This mimics the move group computeCartesianPath signature (without path
+  // constraints).
+  moveit_msgs::srv::GetCartesianPath::Request
+  construct_get_cartesian_plan_request(
+    moveit::planning_interface::MoveGroupInterface& move_group,
+    const std::vector<geometry_msgs::msg::Pose>& waypoints,
+    double step,
+    double jump_threshold,
+    bool avoid_collisions = true);
+
+  // Fetches all cartesian plans that fit within the requested tolerances for
+  // start and goal conditions, returning them as a vector, sorted by some db
+  // column.
+  std::vector<
+    warehouse_ros::MessageWithMetadata<
+      moveit_msgs::msg::RobotTrajectory
+    >::ConstPtr
+  >
+  fetch_all_matching_cartesian_plans(
+    const moveit::planning_interface::MoveGroupInterface& move_group,
+    const std::string& move_group_namespace,
+    const moveit_msgs::srv::GetCartesianPath::Request& plan_request,
+    double min_fraction,
+    double start_tolerance,
+    double goal_tolerance,
+    bool metadata_only = false,
+    const std::string& sort_by = "execution_time_s");
+
+  // Fetches the best cartesian plan that fits within the requested tolerances
+  // for start and goal conditions, by some db column.
+  warehouse_ros::MessageWithMetadata<
+    moveit_msgs::msg::RobotTrajectory
+  >::ConstPtr
+  fetch_best_matching_cartesian_plan(
+    const moveit::planning_interface::MoveGroupInterface& move_group,
+    const std::string& move_group_namespace,
+    const moveit_msgs::srv::GetCartesianPath::Request& plan_request,
+    double min_fraction,
+    double start_tolerance,
+    double goal_tolerance,
+    bool metadata_only = false,
+    const std::string& sort_by = "execution_time_s");
+
+  // Put a cartesian plan into the database if it is the best matching cartesian
+  // plan seen so far.
+  //
+  // Cartesian plans are matched based off their start and goal states.
+  // And are considered "better" if they have a smaller planned execution time
+  // than matching cartesian plans.
+  //
+  // Optionally deletes all worse cartesian plans by default to prune the cache.
+  bool put_cartesian_plan(
+    const moveit::planning_interface::MoveGroupInterface& move_group,
+    const std::string& move_group_namespace,
+    const moveit_msgs::srv::GetCartesianPath::Request& plan_request,
+    const moveit_msgs::msg::RobotTrajectory& plan,
+    double execution_time_s,
+    double planning_time_s,
+    double fraction,
+    bool delete_worse_plans = true);
+
+  // QUERY CONSTRUCTION
+  bool extract_and_append_cartesian_plan_start_to_query(
+    warehouse_ros::Query& query,
+    const moveit::planning_interface::MoveGroupInterface& move_group,
+    const moveit_msgs::srv::GetCartesianPath::Request& plan_request,
+    double match_tolerance);
+
+  bool extract_and_append_cartesian_plan_goal_to_query(
+    warehouse_ros::Query& query,
+    const moveit::planning_interface::MoveGroupInterface& move_group,
+    const moveit_msgs::srv::GetCartesianPath::Request& plan_request,
+    double match_tolerance);
+
+  // METADATA CONSTRUCTION
+  bool extract_and_append_cartesian_plan_start_to_metadata(
+    warehouse_ros::Metadata& metadata,
+    const moveit::planning_interface::MoveGroupInterface& move_group,
+    const moveit_msgs::srv::GetCartesianPath::Request& plan_request);
+
+  bool extract_and_append_cartesian_plan_goal_to_metadata(
+    warehouse_ros::Metadata& metadata,
+    const moveit::planning_interface::MoveGroupInterface& move_group,
+    const moveit_msgs::srv::GetCartesianPath::Request& plan_request);
 
 private:
   rclcpp::Node::SharedPtr node_;

--- a/nexus_motion_planner/src/motion_plan_cache.hpp
+++ b/nexus_motion_planner/src/motion_plan_cache.hpp
@@ -74,7 +74,7 @@ public:
       moveit_msgs::msg::RobotTrajectory
     >::ConstPtr
   >
-  fetchAllMatchingPlans(
+  fetch_all_matching_plans(
     const moveit::planning_interface::MoveGroupInterface& move_group,
     const std::string& move_group_namespace,
     const moveit_msgs::msg::MotionPlanRequest& plan_request,
@@ -83,13 +83,13 @@ public:
   warehouse_ros::MessageWithMetadata<
     moveit_msgs::msg::RobotTrajectory
   >::ConstPtr
-  fetchBestMatchingPlan(
+  fetch_best_matching_plan(
     const moveit::planning_interface::MoveGroupInterface& move_group,
     const std::string& move_group_namespace,
     const moveit_msgs::msg::MotionPlanRequest& plan_request,
     double start_tolerance, double goal_tolerance, bool metadata_only = false);
 
-  bool putPlan(
+  bool put_plan(
     const moveit::planning_interface::MoveGroupInterface& move_group,
     const std::string& move_group_namespace,
     const moveit_msgs::msg::MotionPlanRequest& plan_request,
@@ -98,25 +98,25 @@ public:
     bool overwrite = true);
 
   // QUERY CONSTRUCTION ========================================================
-  bool extractAndAppendStartToQuery(
+  bool extract_and_append_start_to_query(
     warehouse_ros::Query& query,
     const moveit::planning_interface::MoveGroupInterface& move_group,
     const moveit_msgs::msg::MotionPlanRequest& plan_request,
     double match_tolerance);
 
-  bool extractAndAppendGoalToQuery(
+  bool extract_and_append_goal_to_query(
     warehouse_ros::Query& query,
     const moveit::planning_interface::MoveGroupInterface& move_group,
     const moveit_msgs::msg::MotionPlanRequest& plan_request,
     double match_tolerance);
 
   // METADATA CONSTRUCTION =====================================================
-  bool extractAndAppendStartToMetadata(
+  bool extract_and_append_start_to_metadata(
     warehouse_ros::Metadata& metadata,
     const moveit::planning_interface::MoveGroupInterface& move_group,
     const moveit_msgs::msg::MotionPlanRequest& plan_request);
 
-  bool extractAndAppendGoalToMetadata(
+  bool extract_and_append_goal_to_metadata(
     warehouse_ros::Metadata& metadata,
     const moveit::planning_interface::MoveGroupInterface& move_group,
     const moveit_msgs::msg::MotionPlanRequest& plan_request);

--- a/nexus_motion_planner/src/motion_plan_cache.hpp
+++ b/nexus_motion_planner/src/motion_plan_cache.hpp
@@ -1,3 +1,17 @@
+// Copyright 2022 Johnson & Johnson
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef SRC__MOTION_PLAN_CACHE_HPP
 #define SRC__MOTION_PLAN_CACHE_HPP
 

--- a/nexus_motion_planner/src/motion_plan_cache.hpp
+++ b/nexus_motion_planner/src/motion_plan_cache.hpp
@@ -68,7 +68,7 @@ namespace motion_planner {
  *     - Final pose (wrt. `planning_frame` (usually `base_link`))
  *     - Final robot joint states
  *
- * Motion plans may be looked up with some tolerance.
+ * Motion plans may be looked up with some tolerance at call time.
  */
 class MotionPlanCache
 {
@@ -80,7 +80,7 @@ public:
   void init(
     const std::string& db_path = ":memory:",
     uint32_t db_port = 0,
-    double exact_match_precision = 0.00001);
+    double exact_match_precision = 1e-6);
 
   // TOP LEVEL OPS =============================================================
   std::vector<
@@ -140,7 +140,7 @@ private:
   rclcpp::Node::SharedPtr node_;
   warehouse_ros::DatabaseConnection::Ptr db_;
 
-  double exact_match_precision_ = 0;
+  double exact_match_precision_ = 1e-6;
 
   std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
   std::shared_ptr<tf2_ros::TransformListener> tf_listener_;

--- a/nexus_motion_planner/src/motion_plan_cache.hpp
+++ b/nexus_motion_planner/src/motion_plan_cache.hpp
@@ -50,6 +50,8 @@ namespace motion_planner {
  * how long they took to execute. This allows for the lookup and reuse of the
  * best performing plans found so far.
  *
+ * WARNING: This cache does NOT yet support collision detection!
+ *
  * Relevant ROS Parameters:
  *   - `warehouse_plugin`: What database to use
  *   - `warehouse_host`: Where the database should be created
@@ -82,7 +84,10 @@ public:
     uint32_t db_port = 0,
     double exact_match_precision = 1e-6);
 
-  // TOP LEVEL OPS =============================================================
+  // ===========================================================================
+  // MOTION PLAN CACHING
+  // ===========================================================================
+  // TOP LEVEL OPS
   std::vector<
     warehouse_ros::MessageWithMetadata<
       moveit_msgs::msg::RobotTrajectory
@@ -112,26 +117,26 @@ public:
     double planning_time_s,
     bool overwrite = true);
 
-  // QUERY CONSTRUCTION ========================================================
-  bool extract_and_append_start_to_query(
+  // QUERY CONSTRUCTION
+  bool extract_and_append_plan_start_to_query(
     warehouse_ros::Query& query,
     const moveit::planning_interface::MoveGroupInterface& move_group,
     const moveit_msgs::msg::MotionPlanRequest& plan_request,
     double match_tolerance);
 
-  bool extract_and_append_goal_to_query(
+  bool extract_and_append_plan_goal_to_query(
     warehouse_ros::Query& query,
     const moveit::planning_interface::MoveGroupInterface& move_group,
     const moveit_msgs::msg::MotionPlanRequest& plan_request,
     double match_tolerance);
 
-  // METADATA CONSTRUCTION =====================================================
-  bool extract_and_append_start_to_metadata(
+  // METADATA CONSTRUCTION
+  bool extract_and_append_plan_start_to_metadata(
     warehouse_ros::Metadata& metadata,
     const moveit::planning_interface::MoveGroupInterface& move_group,
     const moveit_msgs::msg::MotionPlanRequest& plan_request);
 
-  bool extract_and_append_goal_to_metadata(
+  bool extract_and_append_plan_goal_to_metadata(
     warehouse_ros::Metadata& metadata,
     const moveit::planning_interface::MoveGroupInterface& move_group,
     const moveit_msgs::msg::MotionPlanRequest& plan_request);

--- a/nexus_motion_planner/src/motion_planner_server.cpp
+++ b/nexus_motion_planner/src/motion_planner_server.cpp
@@ -262,7 +262,7 @@ MotionPlannerServer::MotionPlannerServer(const rclcpp::NodeOptions& options)
       "warehouse_port", _cache_db_port);
 
     _motion_plan_cache =
-      std::make_shared<nexus::motion_planner::MotionPlanCache>(
+      std::make_unique<nexus::motion_planner::MotionPlanCache>(
       _internal_cache_node);
   }
 }

--- a/nexus_motion_planner/src/motion_planner_server.cpp
+++ b/nexus_motion_planner/src/motion_planner_server.cpp
@@ -293,11 +293,6 @@ MotionPlannerServer::~MotionPlannerServer()
   {
     _spin_thread.join();
   }
-
-  if (_cache_spin_thread.joinable())
-  {
-    _cache_spin_thread.join();
-  }
 }
 
 //==============================================================================

--- a/nexus_motion_planner/src/motion_planner_server.cpp
+++ b/nexus_motion_planner/src/motion_planner_server.cpp
@@ -285,9 +285,13 @@ MotionPlannerServer::MotionPlannerServer(const rclcpp::NodeOptions& options)
     _internal_node->declare_parameter<int>(
       "warehouse_port", _cache_db_port);
 
-    _motion_plan_cache =
-      std::make_unique<nexus::motion_planner::MotionPlanCache>(_internal_node);
   }
+
+  // We need to construct the cache even if we are not using the DB, since it
+  // has a utility function that uses the internal node that we use to generate
+  // a trajectory start point for cartesian planning.
+  _motion_plan_cache =
+    std::make_unique<nexus::motion_planner::MotionPlanCache>(_internal_node);
 }
 
 //==============================================================================

--- a/nexus_motion_planner/src/motion_planner_server.cpp
+++ b/nexus_motion_planner/src/motion_planner_server.cpp
@@ -704,7 +704,7 @@ void MotionPlannerServer::plan_with_move_group(
             res->result.trajectory.joint_trajectory.points.back()
             .time_from_start
           ).seconds(),
-          plan.planning_time,
+          res->result.planning_time,
           _cache_mode == PlannerDatabaseMode::TrainingOverwrite))
       {
         RCLCPP_WARN(this->get_logger(), "Did not put plan into cache.");

--- a/nexus_motion_planner/src/motion_planner_server.cpp
+++ b/nexus_motion_planner/src/motion_planner_server.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// TODO: Catch warehouse_ros exceptions if they are thrown.
+
 #include "motion_planner_server.hpp"
 
 std::string str_tolower(std::string s)
@@ -42,7 +44,8 @@ PlannerDatabaseMode str_to_planner_database_mode(std::string s)
 {
   std::string s_lower = str_tolower(s);
 
-  // Using a switch-case here is... inconvenient (needs constexpr hashing or a map), so we don't.
+  // Using a switch-case here is... inconvenient (needs constexpr hashing or a
+  // map), so we don't.
   if (s_lower == "training_overwrite" || s_lower == "trainingoverwrite")
   {
     return PlannerDatabaseMode::TrainingOverwrite;
@@ -244,6 +247,7 @@ MotionPlannerServer::MotionPlannerServer(const rclcpp::NodeOptions& options)
     "Setting parameter cache_db_port to [%d]", _cache_db_port
   );
 
+  // For floating point comparison, what counts as an "exact" match.
   _cache_exact_match_tolerance = this->declare_parameter(
     "cache_exact_match_tolerance", 0.0005);  // ~0.028 degrees per joint
   RCLCPP_INFO(
@@ -303,8 +307,12 @@ auto MotionPlannerServer::on_configure(const LifecycleState& /*state*/)
 
   if (_cache_mode != PlannerDatabaseMode::Unset)
   {
-    _motion_plan_cache->init(
-      _cache_db_host, _cache_db_port, _cache_exact_match_tolerance);
+    if (!_motion_plan_cache->init(
+        _cache_db_host, _cache_db_port, _cache_exact_match_tolerance))
+    {
+      RCLCPP_ERROR(this->get_logger(), "Could not init motion plan cache.");
+      return CallbackReturn::ERROR;
+    }
   }
 
   if (_use_move_group_interfaces)
@@ -451,8 +459,7 @@ auto MotionPlannerServer::on_shutdown(const LifecycleState& /*state*/)
 
 //==============================================================================
 void MotionPlannerServer::plan_with_move_group(
-  const GetMotionPlanService::ServiceType::Request& req,
-  Response res)
+  const GetMotionPlanService::ServiceType::Request& req, Response res)
 {
   RCLCPP_INFO(
     this->get_logger(),
@@ -598,24 +605,136 @@ void MotionPlannerServer::plan_with_move_group(
     // TODO(YV): For now we use simple cartesian interpolation. OMPL supports
     // constrained planning so we can consider adding orientation or line
     // constraints to the end-effector link instead and call plan().
-    const double error = interface->computeCartesianPath(
-      waypoints,
-      _cartesian_max_step,
-      _cartesian_jump_threshold,
-      res->result.trajectory,
-      _collision_aware_cartesian_path
-    );
-    RCLCPP_INFO(
-      this->get_logger(),
-      "Cartesian interpolation returned a fraction of [%.2f]", error
-    );
-    if (error <= 0.0)
+
+    moveit_msgs::msg::RobotTrajectory cartesian_plan;
+    double fraction;
+    bool cartesian_plan_is_from_cache = false;
+    auto cartesian_plan_req_msg =
+      _motion_plan_cache->construct_get_cartesian_plan_request(
+      *interface, waypoints, _cartesian_max_step, _cartesian_jump_threshold,
+      _collision_aware_cartesian_path);
+
+    // Fetch if in execute mode.
+    if (cache_mode_is_execute(_cache_mode)
+      || req.force_cache_mode_execute_read_only)
     {
-      res->result.error_code.val = -1;
+      auto fetch_start = this->now();
+      auto fetched_cartesian_plan =
+        _motion_plan_cache->fetch_best_matching_cartesian_plan(
+        *interface, robot_name, cartesian_plan_req_msg,
+        /* min_fraction */ 1.0,
+        _cache_start_match_tolerance, _cache_goal_match_tolerance);
+      auto fetch_end = this->now();
+      // Set plan if a cached cartesian plan was fetched.
+      if (fetched_cartesian_plan)
+      {
+        fraction = fetched_cartesian_plan->lookupDouble("fraction");
+        cartesian_plan_is_from_cache = true;
+        cartesian_plan = *fetched_cartesian_plan;
+        res->result.error_code.val =
+          moveit_msgs::msg::MoveItErrorCodes::SUCCESS;
+        res->result.planning_time = (fetch_end - fetch_start).seconds();
+        RCLCPP_INFO(
+          this->get_logger(),
+          "Cache fetch took %es, planning time of fetched plan was: %es",
+          (fetch_end - fetch_start).seconds(),
+          fetched_cartesian_plan->lookupDouble("planning_time_s"));
+      }
+      // Fail if ReadOnly mode and no cached cartesian plan was fetched.
+      else if (_cache_mode == PlannerDatabaseMode::ExecuteReadOnly
+        || req.force_cache_mode_execute_read_only)
+      {
+        RCLCPP_ERROR(
+          this->get_logger(),
+          "Cache mode was ExecuteReadOnly, and could not find "
+          "cached cartesian plan for cartesian plan request: \n\n%s",
+          moveit_msgs::srv::to_yaml(cartesian_plan_req_msg).c_str());
+        res->result.error_code.val =
+          moveit_msgs::msg::MoveItErrorCodes::FAILURE;
+        return;
+      }
+    }
+
+    // Plan if needed.
+    // This is if we didn't fetch a cartesian plan from the cache.
+    // (In training or unset mode we never attempt to fetch, so it will always
+    // plan.)
+    if (!cartesian_plan_is_from_cache)
+    {
+      auto cartesian_plan_start = this->now();
+      fraction = interface->computeCartesianPath(
+        waypoints,
+        _cartesian_max_step,
+        _cartesian_jump_threshold,
+        cartesian_plan,
+        _collision_aware_cartesian_path
+      );
+      auto cartesian_plan_end = this->now();
+
+      RCLCPP_INFO(
+        this->get_logger(),
+        "Cartesian interpolation returned a fraction of [%.2f]", fraction
+      );
+      if (fraction <= 0.0)
+      {
+        res->result.error_code.val = -1;
+      }
+      else
+      {
+        res->result.error_code.val = 1;
+      }
+
+      res->result.planning_time =
+        (cartesian_plan_end - cartesian_plan_start).seconds();
+
+      RCLCPP_INFO(
+        this->get_logger(),
+        "Plan status: %d, planning time: %es",
+        res->result.error_code.val, res->result.planning_time);
     }
     else
     {
-      res->result.error_code.val = 1;
+      if (fraction <= 0)
+      {
+        res->result.error_code.val = -1;
+      }
+      else
+      {
+        res->result.error_code.val = 1;
+      }
+    }
+
+    // Do NOT move this. We use the cartesian_plan_req_msg later.
+    res->result.trajectory_start = cartesian_plan_req_msg.start_state;
+    res->result.trajectory = std::move(cartesian_plan);
+
+    if (res->result.error_code.val !=
+      moveit_msgs::msg::MoveItErrorCodes::SUCCESS)
+    {
+      RCLCPP_WARN(
+        this->get_logger(),
+        "Cartesian planning did not succeed: %d", res->result.error_code.val);
+      return;
+    }
+
+    // Put plan if in training mode.
+    // Make sure we check if the plan we have was fetched (so we don't have
+    // duplicate caches.)
+    if (cache_mode_is_training(_cache_mode) && !cartesian_plan_is_from_cache)
+    {
+      if (!_motion_plan_cache->put_cartesian_plan(
+          *interface, robot_name,
+          std::move(cartesian_plan_req_msg), std::move(res->result.trajectory),
+          rclcpp::Duration(
+            res->result.trajectory.joint_trajectory.points.back()
+            .time_from_start
+          ).seconds(),
+          res->result.planning_time, fraction,
+          _cache_mode == PlannerDatabaseMode::TrainingOverwrite))
+      {
+        RCLCPP_WARN(
+          this->get_logger(), "Did not put cartesian plan into cache.");
+      }
     }
   }
   else

--- a/nexus_motion_planner/src/motion_planner_server.cpp
+++ b/nexus_motion_planner/src/motion_planner_server.cpp
@@ -612,7 +612,7 @@ void MotionPlannerServer::plan_with_move_group(
     }
     else
     {
-      auto fetched_plan = _motion_plan_cache->fetchBestMatchingPlan(
+      auto fetched_plan = _motion_plan_cache->fetch_best_matching_plan(
         *interface, robot_name, plan_req_msg,
         _cache_start_match_tolerance, _cache_goal_match_tolerance);
       if (fetched_plan)
@@ -650,7 +650,7 @@ void MotionPlannerServer::plan_with_move_group(
 
     if (_use_motion_plan_cache && !req.cartesian)
     {
-      bool plan_put_ok = _motion_plan_cache->putPlan(
+      bool plan_put_ok = _motion_plan_cache->put_plan(
         *interface, robot_name,
         std::move(plan_req_msg), std::move(res->result.trajectory),
         (exec_end - exec_start).seconds(), true);

--- a/nexus_motion_planner/src/motion_planner_server.cpp
+++ b/nexus_motion_planner/src/motion_planner_server.cpp
@@ -14,6 +14,9 @@
 
 #include "motion_planner_server.hpp"
 
+namespace nexus {
+namespace motion_planner {
+
 //==============================================================================
 MotionPlannerServer::MotionPlannerServer(const rclcpp::NodeOptions& options)
 : rclcpp_lifecycle::LifecycleNode("motion_planner_server", options)
@@ -697,3 +700,6 @@ void MotionPlannerServer::plan_with_move_group(
   }
   return;
 }
+
+}  // namespace planning_interface
+}  // namespace moveit

--- a/nexus_motion_planner/src/motion_planner_server.cpp
+++ b/nexus_motion_planner/src/motion_planner_server.cpp
@@ -180,6 +180,14 @@ MotionPlannerServer::MotionPlannerServer(const rclcpp::NodeOptions& options)
     _only_use_cached_plans ? "True" : "False"
   );
 
+  _overwrite_worse_plans = this->declare_parameter(
+    "overwrite_worse_plans", true);
+  RCLCPP_INFO(
+    this->get_logger(),
+    "Setting parameter overwrite_worse_plans to [%s]",
+    _overwrite_worse_plans ? "True" : "False"
+  );
+
   _cache_db_plugin = this->declare_parameter(
     "cache_db_plugin", "warehouse_ros_sqlite::DatabaseConnection");
   RCLCPP_INFO(
@@ -200,7 +208,7 @@ MotionPlannerServer::MotionPlannerServer(const rclcpp::NodeOptions& options)
   );
 
   _cache_exact_match_tolerance = this->declare_parameter(
-    "cache_exact_match_tolerance", 0.025);
+    "cache_exact_match_tolerance", 0.00001);
   RCLCPP_INFO(
     this->get_logger(),
     "Setting parameter cache_exact_match_tolerance to [%.2e]",
@@ -664,7 +672,7 @@ void MotionPlannerServer::plan_with_move_group(
             res->result.trajectory.joint_trajectory.points.back()
             .time_from_start
           ).seconds(),
-          true))
+          _overwrite_worse_plans))
       {
         RCLCPP_WARN(this->get_logger(), "Did not put plan into cache.");
       }

--- a/nexus_motion_planner/src/motion_planner_server.hpp
+++ b/nexus_motion_planner/src/motion_planner_server.hpp
@@ -99,9 +99,6 @@ private:
   rclcpp::Node::SharedPtr _internal_node;
   std::thread _spin_thread;
 
-  rclcpp::Node::SharedPtr _internal_cache_node;
-  std::thread _cache_spin_thread;
-
   // MoveIt planning
   std::vector<std::string> _manipulators;
   bool _use_move_group_interfaces;

--- a/nexus_motion_planner/src/motion_planner_server.hpp
+++ b/nexus_motion_planner/src/motion_planner_server.hpp
@@ -99,7 +99,7 @@ private:
   double _workspace_max_z;
 
   // Motion plan caching
-  std::shared_ptr<nexus::motion_planner::MotionPlanCache> _motion_plan_cache;
+  std::unique_ptr<nexus::motion_planner::MotionPlanCache> _motion_plan_cache;
 
   bool _use_motion_plan_cache;
   bool _use_cached_plans_instead_of_planning;

--- a/nexus_motion_planner/src/motion_planner_server.hpp
+++ b/nexus_motion_planner/src/motion_planner_server.hpp
@@ -99,7 +99,7 @@ private:
   std::shared_ptr<nexus::motion_planner::MotionPlanCache> _motion_plan_cache;
 
   bool _use_motion_plan_cache;
-  bool _only_use_cached_plans;
+  bool _use_cached_plans_instead_of_planning;
   bool _overwrite_worse_plans;
   std::string _cache_db_plugin;
   std::string _cache_db_host;

--- a/nexus_motion_planner/src/motion_planner_server.hpp
+++ b/nexus_motion_planner/src/motion_planner_server.hpp
@@ -100,6 +100,7 @@ private:
 
   bool _use_motion_plan_cache;
   bool _only_use_cached_plans;
+  bool _overwrite_worse_plans;
   std::string _cache_db_plugin;
   std::string _cache_db_host;
   int _cache_db_port;

--- a/nexus_motion_planner/src/motion_planner_server.hpp
+++ b/nexus_motion_planner/src/motion_planner_server.hpp
@@ -127,7 +127,7 @@ private:
   std::string _cache_db_plugin;
   std::string _cache_db_host;
   int _cache_db_port;
-  double _cache_exact_match_tolerance;
+  double _cache_exact_match_tolerance;  // for floating point comparison
   double _cache_start_match_tolerance;
   double _cache_goal_match_tolerance;
 

--- a/nexus_motion_planner/src/motion_planner_server.hpp
+++ b/nexus_motion_planner/src/motion_planner_server.hpp
@@ -41,6 +41,30 @@
 namespace nexus {
 namespace motion_planner {
 
+enum class PlannerDatabaseMode : uint8_t
+{
+  // Unset. Planner will not use a cache.
+  Unset = 0,
+
+  // Planner will always generate a plan.
+  // It will add plans to the database if they are the best seen so far.
+  // Will overwrite close-enough entries if a better plan was found.
+  TrainingOverwrite = 10,
+
+  // Planner will always generate a plan.
+  // It will add plans to the database if they are the best seen so far.
+  // Will not overwrite any existing entries.
+  TrainingAppendOnly = 11,
+
+  // Planner will prioritize returning plans in the cache.
+  // If no plan was found, it will instead attempt to generate a plan live, but will not update the
+  // cache.
+  ExecuteBestEffort = 20,
+
+  // Planner will return a plan only if present in the database cache.
+  ExecuteReadOnly = 21,
+};
+
 //==============================================================================
 class MotionPlannerServer : public rclcpp_lifecycle::LifecycleNode
 {
@@ -100,10 +124,9 @@ private:
 
   // Motion plan caching
   std::unique_ptr<nexus::motion_planner::MotionPlanCache> _motion_plan_cache;
+  std::string _planner_database_mode;
+  PlannerDatabaseMode _cache_mode = PlannerDatabaseMode::Unset;
 
-  bool _use_motion_plan_cache;
-  bool _use_cached_plans_instead_of_planning;
-  bool _overwrite_worse_plans;
   std::string _cache_db_plugin;
   std::string _cache_db_host;
   int _cache_db_port;

--- a/nexus_motion_planner/src/motion_planner_server.hpp
+++ b/nexus_motion_planner/src/motion_planner_server.hpp
@@ -35,6 +35,9 @@
 // NEXUS messages
 #include <nexus_endpoints.hpp>
 
+// NEXUS motion plan cache
+#include "motion_plan_cache.hpp"
+
 //==============================================================================
 class MotionPlannerServer : public rclcpp_lifecycle::LifecycleNode
 {
@@ -69,6 +72,10 @@ private:
   rclcpp::Node::SharedPtr _internal_node;
   std::thread _spin_thread;
 
+  rclcpp::Node::SharedPtr _internal_cache_node;
+  std::thread _cache_spin_thread;
+
+  // MoveIt planning
   std::vector<std::string> _manipulators;
   bool _use_move_group_interfaces;
   bool _use_namespace;
@@ -87,6 +94,18 @@ private:
   double _workspace_max_x;
   double _workspace_max_y;
   double _workspace_max_z;
+
+  // Motion plan caching
+  std::shared_ptr<nexus::motion_planner::MotionPlanCache> _motion_plan_cache;
+
+  bool _use_motion_plan_cache;
+  bool _only_use_cached_plans;
+  std::string _cache_db_plugin;
+  std::string _cache_db_host;
+  int _cache_db_port;
+  double _cache_exact_match_tolerance;
+  double _cache_start_match_tolerance;
+  double _cache_goal_match_tolerance;
 
   rclcpp::Service<GetMotionPlanService::ServiceType>::SharedPtr _plan_srv;
 

--- a/nexus_motion_planner/src/motion_planner_server.hpp
+++ b/nexus_motion_planner/src/motion_planner_server.hpp
@@ -38,6 +38,9 @@
 // NEXUS motion plan cache
 #include "motion_plan_cache.hpp"
 
+namespace nexus {
+namespace motion_planner {
+
 //==============================================================================
 class MotionPlannerServer : public rclcpp_lifecycle::LifecycleNode
 {
@@ -121,5 +124,8 @@ private:
     const GetMotionPlanService::ServiceType::Request& req,
     Response res);
 }; // class MotionPlannerServer
+
+}  // namespace planning_interface
+}  // namespace moveit
 
 #endif // SRC__MOTION_PLANNER_SERVER_HPP

--- a/nexus_motion_planner/src/test_motion_plan_cache.cpp
+++ b/nexus_motion_planner/src/test_motion_plan_cache.cpp
@@ -1,0 +1,1317 @@
+// Copyright 2023 Johnson & Johnson
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <rclcpp/rclcpp.hpp>
+
+#include "moveit/robot_state/conversions.h"
+#include "moveit/robot_state/robot_state.h"
+#include "motion_plan_cache.hpp"
+
+#include <thread>
+
+using moveit::planning_interface::MoveGroupInterface;
+using nexus::motion_planner::MotionPlanCache;
+
+const std::string g_robot_name = "panda";
+const std::string g_robot_frame = "world";
+
+// UTILS =======================================================================
+// Utility function to emit a pass or fail statement.
+void check_and_emit(
+  bool predicate, const std::string& prefix, const std::string& label)
+{
+  if (predicate)
+  {
+    std::cout << "[PASS] " << prefix << ": " << label << std::endl;
+  }
+  else
+  {
+    std::cout << "[FAIL] " << prefix << ": " << label << std::endl;
+    exit(1);
+  }
+}
+
+moveit_msgs::msg::RobotTrajectory get_dummy_panda_plan()
+{
+  static moveit_msgs::msg::RobotTrajectory out = []()
+    {
+      moveit_msgs::msg::RobotTrajectory plan;
+
+      auto traj = &plan.joint_trajectory;
+      traj->header.frame_id = g_robot_frame;
+
+      traj->joint_names.push_back(g_robot_name + "_joint1");
+      traj->joint_names.push_back(g_robot_name + "_joint2");
+      traj->joint_names.push_back(g_robot_name + "_joint3");
+      traj->joint_names.push_back(g_robot_name + "_joint4");
+      traj->joint_names.push_back(g_robot_name + "_joint5");
+      traj->joint_names.push_back(g_robot_name + "_joint6");
+      traj->joint_names.push_back(g_robot_name + "_joint7");
+
+      traj->points.emplace_back();
+      traj->points.at(0).positions = {0, 0, 0, 0, 0, 0};
+      traj->points.at(0).velocities = {0, 0, 0, 0, 0, 0};
+      traj->points.at(0).accelerations = {0, 0, 0, 0, 0, 0};
+      traj->points.at(0).time_from_start.sec = 999999;
+
+      return plan;
+    }();
+  return out;
+}
+
+std::vector<geometry_msgs::msg::Pose> get_dummy_waypoints()
+{
+  static std::vector<geometry_msgs::msg::Pose> out = []()
+    {
+      std::vector<geometry_msgs::msg::Pose> waypoints;
+      for (size_t i = 0; i < 3; i++)
+      {
+        waypoints.emplace_back();
+        waypoints.at(i).position.x = i;
+        waypoints.at(i).position.y = i;
+        waypoints.at(i).position.z = i;
+        waypoints.at(i).orientation.w = i;
+        waypoints.at(i).orientation.x = i + 0.1;
+        waypoints.at(i).orientation.y = i + 0.1;
+        waypoints.at(i).orientation.z = i + 0.1;
+      }
+      return waypoints;
+    }();
+  return out;
+}
+
+
+void test_motion_plans(
+  std::shared_ptr<MoveGroupInterface> move_group,
+  std::shared_ptr<MotionPlanCache> cache)
+{
+  // Setup =====================================================================
+  // All variants are copies.
+
+  /// MotionPlanRequest
+
+  // Plain start
+  moveit_msgs::msg::MotionPlanRequest plan_req;
+  move_group->constructMotionPlanRequest(plan_req);
+  plan_req.workspace_parameters.header.frame_id = g_robot_frame;
+  plan_req.workspace_parameters.max_corner.x = 10;
+  plan_req.workspace_parameters.max_corner.y = 10;
+  plan_req.workspace_parameters.max_corner.z = 10;
+  plan_req.workspace_parameters.min_corner.x = -10;
+  plan_req.workspace_parameters.min_corner.y = -10;
+  plan_req.workspace_parameters.min_corner.z = -10;
+  plan_req.start_state.multi_dof_joint_state.joint_names.clear();
+  plan_req.start_state.multi_dof_joint_state.transforms.clear();
+  plan_req.start_state.multi_dof_joint_state.twist.clear();
+  plan_req.start_state.multi_dof_joint_state.wrench.clear();
+
+  // Empty frame start
+  moveit_msgs::msg::MotionPlanRequest empty_frame_plan_req = plan_req;
+  empty_frame_plan_req.workspace_parameters.header.frame_id = "";
+
+  // is_diff = true
+  auto is_diff_plan_req = plan_req;
+  is_diff_plan_req.start_state.is_diff = true;
+  is_diff_plan_req.start_state.joint_state.header.frame_id = "";
+  is_diff_plan_req.start_state.joint_state.name.clear();
+  is_diff_plan_req.start_state.joint_state.position.clear();
+  is_diff_plan_req.start_state.joint_state.velocity.clear();
+  is_diff_plan_req.start_state.joint_state.effort.clear();
+
+  // Something close enough (mod 0.1 away)
+  auto close_matching_plan_req = plan_req;
+  close_matching_plan_req.workspace_parameters.max_corner.x += 0.05;
+  close_matching_plan_req.workspace_parameters.min_corner.x -= 0.05;
+  close_matching_plan_req.start_state.joint_state.position.at(0) -= 0.05;
+  close_matching_plan_req.start_state.joint_state.position.at(1) += 0.05;
+  close_matching_plan_req.start_state.joint_state.position.at(2) -= 0.05;
+  close_matching_plan_req.goal_constraints
+  .at(0).joint_constraints.at(0).position -= 0.05;
+  close_matching_plan_req.goal_constraints
+  .at(0).joint_constraints.at(1).position += 0.05;
+  close_matching_plan_req.goal_constraints
+  .at(0).joint_constraints.at(2).position -= 0.05;
+
+  // Close with swapped constraints (mod 0.1 away)
+  auto swapped_close_matching_plan_req = close_matching_plan_req;
+  std::swap(
+    swapped_close_matching_plan_req.goal_constraints.at(
+      0).joint_constraints.at(0),
+    swapped_close_matching_plan_req.goal_constraints.at(
+      0).joint_constraints.at(1));
+
+  // Smaller workspace start
+  auto smaller_workspace_plan_req = plan_req;
+  smaller_workspace_plan_req.workspace_parameters.max_corner.x = 1;
+  smaller_workspace_plan_req.workspace_parameters.max_corner.y = 1;
+  smaller_workspace_plan_req.workspace_parameters.max_corner.z = 1;
+  smaller_workspace_plan_req.workspace_parameters.min_corner.x = -1;
+  smaller_workspace_plan_req.workspace_parameters.min_corner.y = -1;
+  smaller_workspace_plan_req.workspace_parameters.min_corner.z = -1;
+
+  // Larger workspace start
+  auto larger_workspace_plan_req = plan_req;
+  larger_workspace_plan_req.workspace_parameters.max_corner.x = 50;
+  larger_workspace_plan_req.workspace_parameters.max_corner.y = 50;
+  larger_workspace_plan_req.workspace_parameters.max_corner.z = 50;
+  larger_workspace_plan_req.workspace_parameters.min_corner.x = -50;
+  larger_workspace_plan_req.workspace_parameters.min_corner.y = -50;
+  larger_workspace_plan_req.workspace_parameters.min_corner.z = -50;
+
+  // Different
+  auto different_plan_req = plan_req;
+  different_plan_req.workspace_parameters.max_corner.x += 1.05;
+  different_plan_req.workspace_parameters.min_corner.x -= 2.05;
+  different_plan_req.start_state.joint_state.position.at(0) -= 3.05;
+  different_plan_req.start_state.joint_state.position.at(1) += 4.05;
+  different_plan_req.start_state.joint_state.position.at(2) -= 5.05;
+  different_plan_req.goal_constraints
+  .at(0).joint_constraints.at(0).position -= 6.05;
+  different_plan_req.goal_constraints
+  .at(0).joint_constraints.at(1).position += 7.05;
+  different_plan_req.goal_constraints
+  .at(0).joint_constraints.at(2).position -= 8.05;
+
+  /// RobotTrajectory
+
+  // Plan
+  auto plan = get_dummy_panda_plan();
+
+  // Plan with no frame_id in its trajectory header
+  auto empty_frame_plan = plan;
+  empty_frame_plan.joint_trajectory.header.frame_id = "";
+
+  auto different_plan = plan;
+  different_plan.joint_trajectory.points.at(0).positions.at(0) = 999;
+  different_plan.joint_trajectory.points.at(0).positions.at(1) = 999;
+  different_plan.joint_trajectory.points.at(0).positions.at(2) = 999;
+
+  // Test Utils
+
+  std::string prefix;
+
+  // Checks ====================================================================
+
+  // Initially empty
+  prefix = "test_motion_plans.empty";
+
+  check_and_emit(
+    cache->count_plans(g_robot_name) == 0,
+    prefix, "Plan cache initially empty");
+
+  check_and_emit(
+    cache->fetch_all_matching_plans(
+      *move_group, g_robot_name, plan_req, 999, 999).empty(),
+    prefix, "Fetch all plans on empty cache returns empty");
+
+  check_and_emit(
+    cache->fetch_best_matching_plan(
+      *move_group, g_robot_name, plan_req, 999, 999) == nullptr,
+    prefix, "Fetch best plan on empty cache returns nullptr");
+
+  // Put plan empty frame
+  //
+  // Plan must have frame in joint trajectory, expect put fail
+  prefix = "test_motion_plans.put_plan_empty_frame";
+  double execution_time = 999;
+  double planning_time = 999;
+
+  check_and_emit(
+    !cache->put_plan(
+      *move_group, g_robot_name, plan_req, empty_frame_plan,
+      execution_time, planning_time, false),
+    prefix, "Put empty frame plan, no delete_worse_plans, not ok");
+
+  check_and_emit(
+    cache->count_plans(g_robot_name) == 0, prefix, "No plans in cache");
+
+  // Put plan req empty frame
+  //
+  // Plan request must have frame in workspace, expect put fail
+  prefix = "test_motion_plans.put_plan_req_empty_frame";
+  execution_time = 999;
+  planning_time = 999;
+
+  check_and_emit(
+    !cache->put_plan(
+      *move_group, g_robot_name, empty_frame_plan_req, plan,
+      execution_time, planning_time, false),
+    prefix, "Put empty frame req plan, no delete_worse_plans, not ok");
+
+  check_and_emit(
+    cache->count_plans(g_robot_name) == 0, prefix, "No plans in cache");
+
+  // Put first, no delete_worse_plans
+  prefix = "test_motion_plans.put_first";
+  execution_time = 999;
+  planning_time = 999;
+
+  check_and_emit(
+    cache->put_plan(
+      *move_group, g_robot_name, plan_req, plan,
+      execution_time, planning_time, false),
+    prefix, "Put first valid plan, no delete_worse_plans, ok");
+
+  check_and_emit(
+    cache->count_plans(g_robot_name) == 1, prefix, "One plan in cache");
+
+  // Fetch matching, no tolerance
+  //
+  // Exact key match should have cache hit
+  prefix = "test_motion_plans.put_first.fetch_matching_no_tolerance";
+
+  auto fetched_plans = cache->fetch_all_matching_plans(
+    *move_group, g_robot_name, plan_req, 0, 0);
+
+  auto fetched_plan = cache->fetch_best_matching_plan(
+    *move_group, g_robot_name, plan_req, 0, 0);
+
+  check_and_emit(fetched_plans.size() == 1, prefix, "Fetch all returns one");
+  check_and_emit(
+    fetched_plan != nullptr, prefix, "Fetch best plan is not nullptr");
+
+  check_and_emit(
+    *fetched_plans.at(0) == *fetched_plan,
+    prefix, "Fetched plan on both fetches match");
+
+  check_and_emit(
+    *fetched_plan == plan, prefix, "Fetched plan matches original");
+
+  check_and_emit(
+    fetched_plan->lookupDouble("execution_time_s") == execution_time,
+    prefix, "Fetched plan has correct execution time");
+
+  check_and_emit(
+    fetched_plan->lookupDouble("planning_time_s") == planning_time,
+    prefix, "Fetched plan has correct planning time");
+
+  // Fetch with is_diff
+  //
+  // is_diff key should be equivalent to exact match if robot state did not
+  // change, hence should have cache hit
+  prefix = "test_motion_plans.put_first.fetch_is_diff_no_tolerance";
+
+  fetched_plans = cache->fetch_all_matching_plans(
+    *move_group, g_robot_name, is_diff_plan_req, 0, 0);
+
+  fetched_plan = cache->fetch_best_matching_plan(
+    *move_group, g_robot_name, is_diff_plan_req, 0, 0);
+
+  check_and_emit(fetched_plans.size() == 1, prefix, "Fetch all returns one");
+  check_and_emit(
+    fetched_plan != nullptr, prefix, "Fetch best plan is not nullptr");
+
+  check_and_emit(
+    *fetched_plans.at(0) == *fetched_plan,
+    prefix, "Fetched plan on both fetches match");
+
+  check_and_emit(
+    *fetched_plan == plan, prefix, "Fetched plan matches original");
+
+  check_and_emit(
+    fetched_plan->lookupDouble("execution_time_s") == execution_time,
+    prefix, "Fetched plan has correct execution time");
+
+  check_and_emit(
+    fetched_plan->lookupDouble("planning_time_s") == planning_time,
+    prefix, "Fetched plan has correct planning time");
+
+  // Fetch non-matching, out of tolerance
+  //
+  // Non-matching key should not have cache hit
+  prefix = "test_motion_plans.put_first.fetch_non_matching_out_of_tolerance";
+
+  fetched_plans = cache->fetch_all_matching_plans(
+    *move_group, g_robot_name, close_matching_plan_req, 0, 0);
+
+  fetched_plan = cache->fetch_best_matching_plan(
+    *move_group, g_robot_name, close_matching_plan_req, 0, 0);
+
+  check_and_emit(fetched_plans.size() == 0, prefix, "Fetch all returns empty");
+  check_and_emit(
+    fetched_plan == nullptr, prefix, "Fetch best plan is nullptr");
+
+  // Fetch non-matching, only start in tolerance (but not goal)
+  //
+  // Non-matching key should not have cache hit
+  prefix =
+    "test_motion_plans.put_first.fetch_non_matching_only_start_in_tolerance";
+
+  fetched_plans = cache->fetch_all_matching_plans(
+    *move_group, g_robot_name, close_matching_plan_req, 999, 0);
+
+  fetched_plan = cache->fetch_best_matching_plan(
+    *move_group, g_robot_name, close_matching_plan_req, 999, 0);
+
+  check_and_emit(fetched_plans.size() == 0, prefix, "Fetch all returns empty");
+  check_and_emit(
+    fetched_plan == nullptr, prefix, "Fetch best plan is nullptr");
+
+  // Fetch non-matching, only goal in tolerance (but not start)
+  //
+  // Non-matching key should not have cache hit
+  prefix =
+    "test_motion_plans.put_first.fetch_non_matching_only_goal_in_tolerance";
+
+  fetched_plans = cache->fetch_all_matching_plans(
+    *move_group, g_robot_name, close_matching_plan_req, 0, 999);
+
+  fetched_plan = cache->fetch_best_matching_plan(
+    *move_group, g_robot_name, close_matching_plan_req, 0, 999);
+
+  check_and_emit(fetched_plans.size() == 0, prefix, "Fetch all returns empty");
+  check_and_emit(
+    fetched_plan == nullptr, prefix, "Fetch best plan is nullptr");
+
+  // Fetch non-matching, in tolerance
+  //
+  // Close key within tolerance limit should have cache hit
+  prefix = "test_motion_plans.put_first.fetch_non_matching_in_tolerance";
+
+  fetched_plans = cache->fetch_all_matching_plans(
+    *move_group, g_robot_name, close_matching_plan_req, 0.1, 0.1);
+
+  fetched_plan = cache->fetch_best_matching_plan(
+    *move_group, g_robot_name, close_matching_plan_req, 0.1, 0.1);
+
+  check_and_emit(fetched_plans.size() == 1, prefix, "Fetch all returns one");
+  check_and_emit(
+    fetched_plan != nullptr, prefix, "Fetch best plan is not nullptr");
+
+  check_and_emit(
+    *fetched_plans.at(0) == *fetched_plan,
+    prefix, "Fetched plan on both fetches match");
+
+  check_and_emit(
+    *fetched_plan == plan, prefix, "Fetched plan matches original");
+
+  check_and_emit(
+    fetched_plan->lookupDouble("execution_time_s") == execution_time,
+    prefix, "Fetched plan has correct execution time");
+
+  check_and_emit(
+    fetched_plan->lookupDouble("planning_time_s") == planning_time,
+    prefix, "Fetched plan has correct planning time");
+
+  // Fetch swapped
+  //
+  // Matches should be mostly invariant to constraint ordering
+  prefix = "test_motion_plans.put_first.fetch_swapped";
+
+  fetched_plans = cache->fetch_all_matching_plans(
+    *move_group, g_robot_name, swapped_close_matching_plan_req, 0.1, 0.1);
+
+  fetched_plan = cache->fetch_best_matching_plan(
+    *move_group, g_robot_name, swapped_close_matching_plan_req, 0.1, 0.1);
+
+  check_and_emit(fetched_plans.size() == 1, prefix, "Fetch all returns one");
+  check_and_emit(
+    fetched_plan != nullptr, prefix, "Fetch best plan is not nullptr");
+
+  check_and_emit(
+    *fetched_plans.at(0) == *fetched_plan,
+    prefix, "Fetched plan on both fetches match");
+
+  check_and_emit(
+    *fetched_plan == plan, prefix, "Fetched plan matches original");
+
+  check_and_emit(
+    fetched_plan->lookupDouble("execution_time_s") == execution_time,
+    prefix, "Fetched plan has correct execution time");
+
+  check_and_emit(
+    fetched_plan->lookupDouble("planning_time_s") == planning_time,
+    prefix, "Fetched plan has correct planning time");
+
+  // Fetch with smaller workspace
+  //
+  // Matching plans with more restrictive workspace requirements should not
+  // pull up plans cached for less restrictive workspace requirements
+  prefix = "test_motion_plans.put_first.fetch_smaller_workspace";
+
+  fetched_plans = cache->fetch_all_matching_plans(
+    *move_group, g_robot_name, smaller_workspace_plan_req, 999, 999);
+
+  fetched_plan = cache->fetch_best_matching_plan(
+    *move_group, g_robot_name, smaller_workspace_plan_req, 999, 999);
+
+  check_and_emit(fetched_plans.size() == 0, prefix, "Fetch all returns empty");
+  check_and_emit(
+    fetched_plan == nullptr, prefix, "Fetch best plan is nullptr");
+
+  // Fetch with larger workspace
+  //
+  // Matching plans with less restrictive workspace requirements should pull up
+  // plans cached for more restrictive workspace requirements
+  prefix = "test_motion_plans.put_first.fetch_larger_workspace";
+
+  fetched_plans = cache->fetch_all_matching_plans(
+    *move_group, g_robot_name, larger_workspace_plan_req, 999, 999);
+
+  fetched_plan = cache->fetch_best_matching_plan(
+    *move_group, g_robot_name, larger_workspace_plan_req, 999, 999);
+
+  check_and_emit(fetched_plans.size() == 1, prefix, "Fetch all returns one");
+  check_and_emit(
+    fetched_plan != nullptr, prefix, "Fetch best plan is not nullptr");
+
+  check_and_emit(
+    *fetched_plans.at(0) == *fetched_plan,
+    prefix, "Fetched plan on both fetches match");
+
+  check_and_emit(
+    *fetched_plan == plan, prefix, "Fetched plan matches original");
+
+  check_and_emit(
+    fetched_plan->lookupDouble("execution_time_s") == execution_time,
+    prefix, "Fetched plan has correct execution time");
+
+  check_and_emit(
+    fetched_plan->lookupDouble("planning_time_s") == planning_time,
+    prefix, "Fetched plan has correct planning time");
+
+  check_and_emit(
+    fetched_plan->lookupDouble(
+      "workspace_parameters.max_corner.x")
+    <= larger_workspace_plan_req.workspace_parameters.max_corner.x,
+    prefix, "Fetched plan has more restrictive workspace max_corner");
+
+  check_and_emit(
+    fetched_plan->lookupDouble(
+      "workspace_parameters.max_corner.x")
+    >= larger_workspace_plan_req.workspace_parameters.min_corner.x,
+    prefix, "Fetched plan has more restrictive workspace min_corner");
+
+  // Put worse, no delete_worse_plans
+  //
+  // Worse plans should not be inserted
+  prefix = "test_motion_plans.put_worse";
+  double worse_execution_time = execution_time + 100;
+
+  check_and_emit(
+    !cache->put_plan(
+      *move_group, g_robot_name, plan_req, plan,
+      worse_execution_time, planning_time, false),
+    prefix, "Put worse plan, no delete_worse_plans, not ok");
+
+  check_and_emit(
+    cache->count_plans(g_robot_name) == 1, prefix, "One plan in cache");
+
+  // Put better, no delete_worse_plans
+  //
+  // Better plans should be inserted
+  prefix = "test_motion_plans.put_better";
+  double better_execution_time = execution_time - 100;
+
+  check_and_emit(
+    cache->put_plan(
+      *move_group, g_robot_name, plan_req, plan,
+      better_execution_time, planning_time, false),
+    prefix, "Put better plan, no delete_worse_plans, ok");
+
+  check_and_emit(
+    cache->count_plans(g_robot_name) == 2, prefix, "Two plans in cache");
+
+  // Fetch sorted
+  //
+  // With multiple plans in cache, fetches should be sorted accordingly
+  prefix = "test_motion_plans.put_better.fetch_sorted";
+
+  fetched_plans = cache->fetch_all_matching_plans(
+    *move_group, g_robot_name, plan_req, 0, 0);
+
+  fetched_plan = cache->fetch_best_matching_plan(
+    *move_group, g_robot_name, plan_req, 0, 0);
+
+  check_and_emit(fetched_plans.size() == 2, prefix, "Fetch all returns two");
+  check_and_emit(
+    fetched_plan != nullptr, prefix, "Fetch best plan is not nullptr");
+
+  check_and_emit(
+    *fetched_plans.at(0) == *fetched_plan,
+    prefix, "Fetched plan on both fetches match");
+
+  check_and_emit(
+    *fetched_plan == plan, prefix, "Fetched plan matches original");
+
+  check_and_emit(
+    fetched_plan->lookupDouble("execution_time_s") == better_execution_time,
+    prefix, "Fetched plan has correct execution time");
+
+  check_and_emit(
+    fetched_plan->lookupDouble("planning_time_s") == planning_time,
+    prefix, "Fetched plan has correct planning time");
+
+  check_and_emit(
+    fetched_plans.at(0)->lookupDouble(
+      "execution_time_s") == better_execution_time
+    && fetched_plans.at(1)->lookupDouble("execution_time_s") == execution_time,
+    prefix, "Fetched plans are sorted correctly");
+
+  // Put better, delete_worse_plans
+  //
+  // Better, different, plans should be inserted
+  prefix = "test_motion_plans.put_better_delete_worse_plans";
+  double even_better_execution_time = better_execution_time - 100;
+
+  check_and_emit(
+    cache->put_plan(
+      *move_group, g_robot_name, plan_req, different_plan,
+      even_better_execution_time, planning_time, true),
+    prefix, "Put better plan, delete_worse_plans, ok");
+
+  check_and_emit(
+    cache->count_plans(g_robot_name) == 1, prefix, "One plan in cache");
+
+  // Fetch better plan
+  prefix = "test_motion_plans.put_better_delete_worse_plans.fetch";
+
+  fetched_plans = cache->fetch_all_matching_plans(
+    *move_group, g_robot_name, plan_req, 0, 0);
+
+  fetched_plan = cache->fetch_best_matching_plan(
+    *move_group, g_robot_name, plan_req, 0, 0);
+
+  check_and_emit(fetched_plans.size() == 1, prefix, "Fetch all returns one");
+  check_and_emit(
+    fetched_plan != nullptr, prefix, "Fetch best plan is not nullptr");
+
+  check_and_emit(
+    *fetched_plans.at(0) == *fetched_plan,
+    prefix, "Fetched plan on both fetches match");
+
+  check_and_emit(
+    *fetched_plan == different_plan, prefix, "Fetched plan matches original");
+
+  check_and_emit(
+    fetched_plan->lookupDouble(
+      "execution_time_s") == even_better_execution_time,
+    prefix, "Fetched plan has correct execution time");
+
+  check_and_emit(
+    fetched_plan->lookupDouble("planning_time_s") == planning_time,
+    prefix, "Fetched plan has correct planning time");
+
+  // Put different req, delete_worse_plans
+  //
+  // Unrelated plan requests should live alongside pre-existing plans
+  prefix = "test_motion_plans.put_different_req";
+
+  check_and_emit(
+    cache->put_plan(
+      *move_group, g_robot_name, different_plan_req, different_plan,
+      better_execution_time, planning_time, true),
+    prefix, "Put different plan req, delete_worse_plans, ok");
+
+  check_and_emit(
+    cache->count_plans(g_robot_name) == 2, prefix, "Two plans in cache");
+
+  // Fetch with different plan req
+  //
+  // With multiple plans in cache, fetches should be sorted accordingly
+  prefix = "test_motion_plans.put_different_req.fetch";
+
+  fetched_plans = cache->fetch_all_matching_plans(
+    *move_group, g_robot_name, different_plan_req, 0, 0);
+
+  fetched_plan = cache->fetch_best_matching_plan(
+    *move_group, g_robot_name, different_plan_req, 0, 0);
+
+  check_and_emit(fetched_plans.size() == 1, prefix, "Fetch all returns one");
+  check_and_emit(
+    fetched_plan != nullptr, prefix, "Fetch best plan is not nullptr");
+
+  check_and_emit(
+    *fetched_plans.at(0) == *fetched_plan,
+    prefix, "Fetched plan on both fetches match");
+
+  check_and_emit(
+    *fetched_plan == different_plan, prefix, "Fetched plan matches original");
+
+  check_and_emit(
+    fetched_plan->lookupDouble(
+      "execution_time_s") == better_execution_time,
+    prefix, "Fetched plan has correct execution time");
+
+  check_and_emit(
+    fetched_plan->lookupDouble("planning_time_s") == planning_time,
+    prefix, "Fetched plan has correct planning time");
+
+  // Fetch different robot
+  //
+  // Since we didn't populate anything, we should expect empty
+  prefix = "test_motion_plans.different_robot.empty";
+  std::string different_robot_name = "different_robot";
+
+  check_and_emit(
+    cache->count_cartesian_plans(different_robot_name) == 0,
+    prefix, "No plans in cache");
+
+  // Put first for different robot, delete_worse_plans
+  //
+  // A different robot's cache should not interact with the original cache
+  prefix = "test_motion_plans.different_robot.put_first";
+  check_and_emit(
+    cache->put_plan(
+      *move_group, different_robot_name, different_plan_req,
+      different_plan, better_execution_time, planning_time, true),
+    prefix, "Put different plan req, delete_worse_plans, ok");
+
+  check_and_emit(
+    cache->count_plans(different_robot_name) == 1,
+    prefix, "One plans in cache");
+
+  check_and_emit(
+    cache->count_plans(different_robot_name) == 1,
+    prefix, "One plans in cache");
+
+  check_and_emit(
+    cache->count_plans(g_robot_name) == 2,
+    prefix, "Two plans in original robot's cache");
+
+  fetched_plans = cache->fetch_all_matching_plans(
+    *move_group, g_robot_name, different_plan_req, 0, 0);
+
+  check_and_emit(fetched_plans.size() == 1, prefix,
+    "Fetch all on original still returns one");
+}
+
+void test_cartesian_plans(
+  std::shared_ptr<MoveGroupInterface> move_group,
+  std::shared_ptr<MotionPlanCache> cache)
+{
+  std::string prefix;
+
+  /// First, test if construction even works...
+
+  // Construct get cartesian plan request
+  prefix = "test_cartesian_plans.construct_get_cartesian_path_request";
+
+  int test_step = 1;
+  int test_jump = 2;
+  auto test_waypoints = get_dummy_waypoints();
+  auto cartesian_plan_req_under_test =
+    cache->construct_get_cartesian_plan_request(
+    *move_group, test_waypoints, test_step, test_jump, false);
+
+  check_and_emit(
+    cartesian_plan_req_under_test.waypoints == test_waypoints
+    && static_cast<int>(
+      cartesian_plan_req_under_test.max_step) == test_step
+    && static_cast<int>(
+      cartesian_plan_req_under_test.jump_threshold) == test_jump
+    && !cartesian_plan_req_under_test.avoid_collisions,
+    prefix, "Ok");
+
+  // Setup =====================================================================
+  // All variants are copies.
+
+  /// GetCartesianPath::Request
+
+  // Plain start
+  auto waypoints = get_dummy_waypoints();
+  auto cartesian_plan_req = cache
+    ->construct_get_cartesian_plan_request(*move_group, waypoints, 1, 1, false);
+  cartesian_plan_req.start_state.multi_dof_joint_state.joint_names.clear();
+  cartesian_plan_req.start_state.multi_dof_joint_state.transforms.clear();
+  cartesian_plan_req.start_state.multi_dof_joint_state.twist.clear();
+  cartesian_plan_req.start_state.multi_dof_joint_state.wrench.clear();
+  cartesian_plan_req.path_constraints.joint_constraints.clear();
+  cartesian_plan_req.path_constraints.position_constraints.clear();
+  cartesian_plan_req.path_constraints.orientation_constraints.clear();
+  cartesian_plan_req.path_constraints.visibility_constraints.clear();
+
+  // Empty frame start
+  auto empty_frame_cartesian_plan_req = cartesian_plan_req;
+  empty_frame_cartesian_plan_req.header.frame_id = "";
+
+  // is_diff = true
+  auto is_diff_cartesian_plan_req = cartesian_plan_req;
+  is_diff_cartesian_plan_req.start_state.is_diff = true;
+  is_diff_cartesian_plan_req.start_state.joint_state.header.frame_id = "";
+  is_diff_cartesian_plan_req.start_state.joint_state.name.clear();
+  is_diff_cartesian_plan_req.start_state.joint_state.position.clear();
+  is_diff_cartesian_plan_req.start_state.joint_state.velocity.clear();
+  is_diff_cartesian_plan_req.start_state.joint_state.effort.clear();
+
+  // Something close enough (mod 0.1 away)
+  auto close_matching_cartesian_plan_req = cartesian_plan_req;
+  close_matching_cartesian_plan_req.start_state.joint_state.position.at(0) -=
+    0.05;
+  close_matching_cartesian_plan_req.start_state.joint_state.position.at(1) +=
+    0.05;
+  close_matching_cartesian_plan_req.start_state.joint_state.position.at(2) -=
+    0.05;
+  close_matching_cartesian_plan_req.waypoints.at(0).position.x -= 0.05;
+  close_matching_cartesian_plan_req.waypoints.at(1).position.x += 0.05;
+  close_matching_cartesian_plan_req.waypoints.at(2).position.x -= 0.05;
+
+  // Different
+  auto different_cartesian_plan_req = cartesian_plan_req;
+  different_cartesian_plan_req.start_state.joint_state.position.at(0) -= 1.05;
+  different_cartesian_plan_req.start_state.joint_state.position.at(1) += 2.05;
+  different_cartesian_plan_req.start_state.joint_state.position.at(2) -= 3.05;
+  different_cartesian_plan_req.waypoints.at(0).position.x -= 1.05;
+  different_cartesian_plan_req.waypoints.at(1).position.x += 2.05;
+  different_cartesian_plan_req.waypoints.at(2).position.x -= 3.05;
+
+  /// RobotTrajectory
+
+  // Plan
+  auto plan = get_dummy_panda_plan();
+
+  // Plan with no frame_id in its trajectory header
+  auto empty_frame_plan = plan;
+  empty_frame_plan.joint_trajectory.header.frame_id = "";
+
+  auto different_plan = plan;
+  different_plan.joint_trajectory.points.at(0).positions.at(0) = 999;
+  different_plan.joint_trajectory.points.at(0).positions.at(1) = 999;
+  different_plan.joint_trajectory.points.at(0).positions.at(2) = 999;
+
+  // Checks ====================================================================
+
+  // Initially empty
+  prefix = "test_cartesian_plans.empty";
+
+  check_and_emit(
+    cache->count_cartesian_plans(g_robot_name) == 0,
+    prefix, "Plan cache initially empty");
+
+  check_and_emit(
+    cache->fetch_all_matching_cartesian_plans(
+      *move_group, g_robot_name, cartesian_plan_req, 0, 999, 999).empty(),
+    prefix, "Fetch all plans on empty cache returns empty");
+
+  check_and_emit(
+    cache->fetch_best_matching_cartesian_plan(
+      *move_group, g_robot_name, cartesian_plan_req, 0, 999, 999) == nullptr,
+    prefix, "Fetch best plan on empty cache returns nullptr");
+
+  // Put plan empty frame
+  //
+  // Plan must have frame in joint trajectory, expect put fail
+  prefix = "test_cartesian_plans.put_plan_empty_frame";
+  double execution_time = 999;
+  double planning_time = 999;
+  double fraction = 0.5;
+
+  check_and_emit(
+    !cache->put_cartesian_plan(
+      *move_group, g_robot_name, cartesian_plan_req, empty_frame_plan,
+      execution_time, planning_time, fraction, false),
+    prefix, "Put empty frame plan, no delete_worse_plans, not ok");
+
+  check_and_emit(
+    cache->count_cartesian_plans(g_robot_name) == 0,
+    prefix, "No plans in cache");
+
+  // Put plan req empty frame
+  //
+  // Plan request must have frame in workspace, expect put fail
+  prefix = "test_cartesian_plans.put_plan_req_empty_frame";
+  execution_time = 999;
+  planning_time = 999;
+
+  check_and_emit(
+    !cache->put_cartesian_plan(
+      *move_group, g_robot_name, empty_frame_cartesian_plan_req, plan,
+      execution_time, planning_time, fraction, false),
+    prefix, "Put empty frame req plan, no delete_worse_plans, not ok");
+
+  check_and_emit(
+    cache->count_cartesian_plans(g_robot_name) == 0,
+    prefix, "No plans in cache");
+
+  // Put first, no delete_worse_plans
+  prefix = "test_cartesian_plans.put_first";
+  execution_time = 999;
+  planning_time = 999;
+
+  check_and_emit(
+    cache->put_cartesian_plan(
+      *move_group, g_robot_name, cartesian_plan_req, plan,
+      execution_time, planning_time, fraction, false),
+    prefix, "Put first valid plan, no delete_worse_plans, ok");
+
+  check_and_emit(
+    cache->count_cartesian_plans(g_robot_name) == 1,
+    prefix, "One plan in cache");
+
+  // Fetch matching, no tolerance
+  //
+  // Exact key match should have cache hit
+  prefix = "test_cartesian_plans.put_first.fetch_matching_no_tolerance";
+
+  auto fetched_plans = cache->fetch_all_matching_cartesian_plans(
+    *move_group, g_robot_name, cartesian_plan_req, fraction, 0, 0);
+
+  auto fetched_plan = cache->fetch_best_matching_cartesian_plan(
+    *move_group, g_robot_name, cartesian_plan_req, fraction, 0, 0);
+
+  check_and_emit(fetched_plans.size() == 1, prefix, "Fetch all returns one");
+  check_and_emit(
+    fetched_plan != nullptr, prefix, "Fetch best plan is not nullptr");
+
+  check_and_emit(
+    *fetched_plans.at(0) == *fetched_plan,
+    prefix, "Fetched plan on both fetches match");
+
+  check_and_emit(
+    *fetched_plan == plan, prefix, "Fetched plan matches original");
+
+  check_and_emit(
+    fetched_plan->lookupDouble("execution_time_s") == execution_time,
+    prefix, "Fetched plan has correct execution time");
+
+  check_and_emit(
+    fetched_plan->lookupDouble("planning_time_s") == planning_time,
+    prefix, "Fetched plan has correct planning time");
+
+  check_and_emit(
+    fetched_plan->lookupDouble("fraction") == fraction,
+    prefix, "Fetched plan has correct fraction");
+
+  // Fetch with is_diff
+  //
+  // is_diff key should be equivalent to exact match if robot state did not
+  // change, hence should have cache hit
+  prefix = "test_cartesian_plans.put_first.fetch_is_diff_no_tolerance";
+
+  fetched_plans = cache->fetch_all_matching_cartesian_plans(
+    *move_group, g_robot_name, is_diff_cartesian_plan_req, fraction, 0, 0);
+
+  fetched_plan = cache->fetch_best_matching_cartesian_plan(
+    *move_group, g_robot_name, is_diff_cartesian_plan_req, fraction, 0, 0);
+
+  check_and_emit(fetched_plans.size() == 1, prefix, "Fetch all returns one");
+  check_and_emit(
+    fetched_plan != nullptr, prefix, "Fetch best plan is not nullptr");
+
+  check_and_emit(
+    *fetched_plans.at(0) == *fetched_plan,
+    prefix, "Fetched plan on both fetches match");
+
+  check_and_emit(
+    *fetched_plan == plan, prefix, "Fetched plan matches original");
+
+  check_and_emit(
+    fetched_plan->lookupDouble("execution_time_s") == execution_time,
+    prefix, "Fetched plan has correct execution time");
+
+  check_and_emit(
+    fetched_plan->lookupDouble("planning_time_s") == planning_time,
+    prefix, "Fetched plan has correct planning time");
+
+  check_and_emit(
+    fetched_plan->lookupDouble("fraction") == fraction,
+    prefix, "Fetched plan has correct fraction");
+
+  // Fetch non-matching, out of tolerance
+  //
+  // Non-matching key should not have cache hit
+  prefix = "test_cartesian_plans.put_first.fetch_non_matching_out_of_tolerance";
+
+  fetched_plans = cache->fetch_all_matching_cartesian_plans(
+    *move_group, g_robot_name, close_matching_cartesian_plan_req,
+    fraction, 0, 0);
+
+  fetched_plan = cache->fetch_best_matching_cartesian_plan(
+    *move_group, g_robot_name, close_matching_cartesian_plan_req,
+    fraction, 0, 0);
+
+  check_and_emit(fetched_plans.size() == 0, prefix, "Fetch all returns empty");
+  check_and_emit(
+    fetched_plan == nullptr, prefix, "Fetch best plan is nullptr");
+
+  // Fetch non-matching, only start in tolerance (but not goal)
+  //
+  // Non-matching key should not have cache hit
+  prefix =
+    "test_motion_plans.put_first.fetch_non_matching_only_start_in_tolerance";
+
+  fetched_plans = cache->fetch_all_matching_cartesian_plans(
+    *move_group, g_robot_name, close_matching_cartesian_plan_req,
+    fraction, 999, 0);
+
+  fetched_plan = cache->fetch_best_matching_cartesian_plan(
+    *move_group, g_robot_name, close_matching_cartesian_plan_req,
+    fraction, 999, 0);
+
+  check_and_emit(fetched_plans.size() == 0, prefix, "Fetch all returns empty");
+  check_and_emit(
+    fetched_plan == nullptr, prefix, "Fetch best plan is nullptr");
+
+  // Fetch non-matching, only goal in tolerance (but not start)
+  //
+  // Non-matching key should not have cache hit
+  prefix =
+    "test_motion_plans.put_first.fetch_non_matching_only_goal_in_tolerance";
+
+  fetched_plans = cache->fetch_all_matching_cartesian_plans(
+    *move_group, g_robot_name, close_matching_cartesian_plan_req,
+    fraction, 0, 999);
+
+  fetched_plan = cache->fetch_best_matching_cartesian_plan(
+    *move_group, g_robot_name, close_matching_cartesian_plan_req,
+    fraction, 0, 999);
+
+  check_and_emit(fetched_plans.size() == 0, prefix, "Fetch all returns empty");
+  check_and_emit(
+    fetched_plan == nullptr, prefix, "Fetch best plan is nullptr");
+
+  // Fetch non-matching, in tolerance
+  //
+  // Close key within tolerance limit should have cache hit
+  prefix = "test_cartesian_plans.put_first.fetch_non_matching_in_tolerance";
+
+  fetched_plans = cache->fetch_all_matching_cartesian_plans(
+    *move_group, g_robot_name, close_matching_cartesian_plan_req,
+    fraction, 0.1, 0.1);
+
+  fetched_plan = cache->fetch_best_matching_cartesian_plan(
+    *move_group, g_robot_name, close_matching_cartesian_plan_req,
+    fraction, 0.1, 0.1);
+
+  check_and_emit(fetched_plans.size() == 1, prefix, "Fetch all returns one");
+  check_and_emit(
+    fetched_plan != nullptr, prefix, "Fetch best plan is not nullptr");
+
+  check_and_emit(
+    *fetched_plans.at(0) == *fetched_plan,
+    prefix, "Fetched plan on both fetches match");
+
+  check_and_emit(
+    *fetched_plan == plan, prefix, "Fetched plan matches original");
+
+  check_and_emit(
+    fetched_plan->lookupDouble("execution_time_s") == execution_time,
+    prefix, "Fetched plan has correct execution time");
+
+  check_and_emit(
+    fetched_plan->lookupDouble("planning_time_s") == planning_time,
+    prefix, "Fetched plan has correct planning time");
+
+  check_and_emit(
+    fetched_plan->lookupDouble("fraction") == fraction,
+    prefix, "Fetched plan has correct fraction");
+
+  // Fetch with higher fraction
+  //
+  // Matching plans with more restrictive fraction requirements should not
+  // pull up plans cached for less restrictive fraction requirements
+  prefix = "test_cartesian_plans.put_first.fetch_higher_fraction";
+
+  fetched_plans = cache->fetch_all_matching_cartesian_plans(
+    *move_group, g_robot_name, cartesian_plan_req, 1, 999, 999);
+
+  fetched_plan = cache->fetch_best_matching_cartesian_plan(
+    *move_group, g_robot_name, cartesian_plan_req, 1, 999, 999);
+
+  check_and_emit(fetched_plans.size() == 0, prefix, "Fetch all returns empty");
+  check_and_emit(
+    fetched_plan == nullptr, prefix, "Fetch best plan is nullptr");
+
+  // Fetch with lower fraction
+  //
+  // Matching plans with less restrictive fraction requirements should pull up
+  // plans cached for more restrictive fraction requirements
+  prefix = "test_cartesian_plans.put_first.fetch_lower_fraction";
+
+  fetched_plans = cache->fetch_all_matching_cartesian_plans(
+    *move_group, g_robot_name, cartesian_plan_req, 0, 999, 999);
+
+  fetched_plan = cache->fetch_best_matching_cartesian_plan(
+    *move_group, g_robot_name, cartesian_plan_req, 0, 999, 999);
+
+  check_and_emit(fetched_plans.size() == 1, prefix, "Fetch all returns one");
+  check_and_emit(
+    fetched_plan != nullptr, prefix, "Fetch best plan is not nullptr");
+
+  check_and_emit(
+    *fetched_plans.at(0) == *fetched_plan,
+    prefix, "Fetched plan on both fetches match");
+
+  check_and_emit(
+    *fetched_plan == plan, prefix, "Fetched plan matches original");
+
+  check_and_emit(
+    fetched_plan->lookupDouble("execution_time_s") == execution_time,
+    prefix, "Fetched plan has correct execution time");
+
+  check_and_emit(
+    fetched_plan->lookupDouble("planning_time_s") == planning_time,
+    prefix, "Fetched plan has correct planning time");
+
+  check_and_emit(
+    fetched_plan->lookupDouble("fraction") == fraction,
+    prefix, "Fetched plan has correct fraction");
+
+  // Put worse, no delete_worse_plans
+  //
+  // Worse plans should not be inserted
+  prefix = "test_cartesian_plans.put_worse";
+  double worse_execution_time = execution_time + 100;
+
+  check_and_emit(
+    !cache->put_cartesian_plan(
+      *move_group, g_robot_name, cartesian_plan_req, plan,
+      worse_execution_time, planning_time, fraction, false),
+    prefix, "Put worse plan, no delete_worse_plans, not ok");
+
+  check_and_emit(
+    cache->count_cartesian_plans(g_robot_name) == 1,
+    prefix, "One plan in cache");
+
+  // Put better, no delete_worse_plans
+  //
+  // Better plans should be inserted
+  prefix = "test_cartesian_plans.put_better";
+  double better_execution_time = execution_time - 100;
+
+  check_and_emit(
+    cache->put_cartesian_plan(
+      *move_group, g_robot_name, cartesian_plan_req, plan,
+      better_execution_time, planning_time, fraction, false),
+    prefix, "Put better plan, no delete_worse_plans, ok");
+
+  check_and_emit(
+    cache->count_cartesian_plans(g_robot_name) == 2,
+    prefix, "Two plans in cache");
+
+  // Fetch sorted
+  //
+  // With multiple plans in cache, fetches should be sorted accordingly
+  prefix = "test_cartesian_plans.put_better.fetch_sorted";
+
+  fetched_plans = cache->fetch_all_matching_cartesian_plans(
+    *move_group, g_robot_name, cartesian_plan_req, fraction, 0, 0);
+
+  fetched_plan = cache->fetch_best_matching_cartesian_plan(
+    *move_group, g_robot_name, cartesian_plan_req, fraction, 0, 0);
+
+  check_and_emit(fetched_plans.size() == 2, prefix, "Fetch all returns two");
+  check_and_emit(
+    fetched_plan != nullptr, prefix, "Fetch best plan is not nullptr");
+
+  check_and_emit(
+    *fetched_plans.at(0) == *fetched_plan,
+    prefix, "Fetched plan on both fetches match");
+
+  check_and_emit(
+    *fetched_plan == plan, prefix, "Fetched plan matches original");
+
+  check_and_emit(
+    fetched_plan->lookupDouble("execution_time_s") == better_execution_time,
+    prefix, "Fetched plan has correct execution time");
+
+  check_and_emit(
+    fetched_plan->lookupDouble("planning_time_s") == planning_time,
+    prefix, "Fetched plan has correct planning time");
+
+  check_and_emit(
+    fetched_plan->lookupDouble("fraction") == fraction,
+    prefix, "Fetched plan has correct fraction");
+
+  check_and_emit(
+    fetched_plans.at(0)->lookupDouble(
+      "execution_time_s") == better_execution_time
+    && fetched_plans.at(1)->lookupDouble("execution_time_s") == execution_time,
+    prefix, "Fetched plans are sorted correctly");
+
+  // Put better, delete_worse_plans
+  //
+  // Better, different, plans should be inserted
+  prefix = "test_cartesian_plans.put_better_delete_worse_plans";
+  double even_better_execution_time = better_execution_time - 100;
+
+  check_and_emit(
+    cache->put_cartesian_plan(
+      *move_group, g_robot_name, cartesian_plan_req, different_plan,
+      even_better_execution_time, planning_time, fraction, true),
+    prefix, "Put better plan, delete_worse_plans, ok");
+
+  check_and_emit(
+    cache->count_cartesian_plans(g_robot_name) == 1,
+    prefix, "One plan in cache");
+
+  // Fetch better plan
+  prefix = "test_cartesian_plans.put_better_delete_worse_plans.fetch";
+
+  fetched_plans = cache->fetch_all_matching_cartesian_plans(
+    *move_group, g_robot_name, cartesian_plan_req, fraction, 0, 0);
+
+  fetched_plan = cache->fetch_best_matching_cartesian_plan(
+    *move_group, g_robot_name, cartesian_plan_req, fraction, 0, 0);
+
+  check_and_emit(fetched_plans.size() == 1, prefix, "Fetch all returns one");
+  check_and_emit(
+    fetched_plan != nullptr, prefix, "Fetch best plan is not nullptr");
+
+  check_and_emit(
+    *fetched_plans.at(0) == *fetched_plan,
+    prefix, "Fetched plan on both fetches match");
+
+  check_and_emit(
+    *fetched_plan == different_plan, prefix, "Fetched plan matches original");
+
+  check_and_emit(
+    fetched_plan->lookupDouble(
+      "execution_time_s") == even_better_execution_time,
+    prefix, "Fetched plan has correct execution time");
+
+  check_and_emit(
+    fetched_plan->lookupDouble("planning_time_s") == planning_time,
+    prefix, "Fetched plan has correct planning time");
+
+  check_and_emit(
+    fetched_plan->lookupDouble("fraction") == fraction,
+    prefix, "Fetched plan has correct fraction");
+
+  // Put different req, delete_worse_plans
+  //
+  // Unrelated plan requests should live alongside pre-existing plans
+  prefix = "test_cartesian_plans.put_different_req";
+
+  check_and_emit(
+    cache->put_cartesian_plan(
+      *move_group, g_robot_name, different_cartesian_plan_req, different_plan,
+      better_execution_time, planning_time, fraction, true),
+    prefix, "Put different plan req, delete_worse_plans, ok");
+
+  check_and_emit(
+    cache->count_cartesian_plans(g_robot_name) == 2,
+    prefix, "Two plans in cache");
+
+  // Fetch with different plan req
+  //
+  // With multiple plans in cache, fetches should be sorted accordingly
+  prefix = "test_cartesian_plans.put_different_req.fetch";
+
+  fetched_plans = cache->fetch_all_matching_cartesian_plans(
+    *move_group, g_robot_name, different_cartesian_plan_req, fraction, 0, 0);
+
+  fetched_plan = cache->fetch_best_matching_cartesian_plan(
+    *move_group, g_robot_name, different_cartesian_plan_req, fraction, 0, 0);
+
+  check_and_emit(fetched_plans.size() == 1, prefix, "Fetch all returns one");
+  check_and_emit(
+    fetched_plan != nullptr, prefix, "Fetch best plan is not nullptr");
+
+  check_and_emit(
+    *fetched_plans.at(0) == *fetched_plan,
+    prefix, "Fetched plan on both fetches match");
+
+  check_and_emit(
+    *fetched_plan == different_plan, prefix, "Fetched plan matches original");
+
+  check_and_emit(
+    fetched_plan->lookupDouble(
+      "execution_time_s") == better_execution_time,
+    prefix, "Fetched plan has correct execution time");
+
+  check_and_emit(
+    fetched_plan->lookupDouble("planning_time_s") == planning_time,
+    prefix, "Fetched plan has correct planning time");
+
+  check_and_emit(
+    fetched_plan->lookupDouble("fraction") == fraction,
+    prefix, "Fetched plan has correct fraction");
+
+  // Fetch different robot
+  //
+  // Since we didn't populate anything, we should expect empty
+  prefix = "test_cartesian_plans.different_robot.empty";
+  std::string different_robot_name = "different_robot";
+
+  check_and_emit(
+    cache->count_cartesian_plans(different_robot_name) == 0,
+    prefix, "No plans in cache");
+
+  // Put first for different robot, delete_worse_plans
+  //
+  // A different robot's cache should not interact with the original cache
+  prefix = "test_cartesian_plans.different_robot.put_first";
+  check_and_emit(
+    cache->put_cartesian_plan(
+      *move_group, different_robot_name, different_cartesian_plan_req,
+      different_plan, better_execution_time, planning_time, fraction, true),
+    prefix, "Put different plan req, delete_worse_plans, ok");
+
+  check_and_emit(
+    cache->count_cartesian_plans(different_robot_name) == 1,
+    prefix, "One plans in cache");
+
+  check_and_emit(
+    cache->count_cartesian_plans(different_robot_name) == 1,
+    prefix, "One plans in cache");
+
+  check_and_emit(
+    cache->count_cartesian_plans(g_robot_name) == 2,
+    prefix, "Two plans in original robot's cache");
+
+  fetched_plans = cache->fetch_all_matching_cartesian_plans(
+    *move_group, g_robot_name, different_cartesian_plan_req, fraction, 0, 0);
+
+  check_and_emit(fetched_plans.size() == 1, prefix,
+    "Fetch all on original still returns one");
+}
+
+int main(int argc, char** argv)
+{
+  // Setup
+  rclcpp::init(argc, argv);
+  rclcpp::NodeOptions node_options;
+  node_options.automatically_declare_parameters_from_overrides(true);
+
+  auto test_node = rclcpp::Node::make_shared("test_node", node_options);
+  std::thread spin_thread(
+    [&]()
+    {
+      while (rclcpp::ok())
+      {
+        rclcpp::spin_some(test_node);
+      }
+    }
+  );
+
+  // This is necessary
+  test_node->declare_parameter<std::string>(
+    "warehouse_plugin", "warehouse_ros_sqlite::DatabaseConnection");
+
+  // Test proper
+  {
+    auto cache = std::make_shared<MotionPlanCache>(test_node);
+    check_and_emit(cache->init(":memory:", 0, 1e-4), "init", "Cache init");
+
+    auto move_group =
+      std::make_shared<MoveGroupInterface>(test_node, "panda_arm");
+
+    auto curr_state = move_group->getCurrentState();
+    move_group->setStartState(*curr_state);
+
+    test_motion_plans(move_group, cache);
+    test_cartesian_plans(move_group, cache);
+  }
+
+  rclcpp::shutdown();
+  spin_thread.join();
+
+  return 0;
+}
+
+// CARTESIAN PLANS ===
+
+// Check construct plan request
+// Remember to check fraction too!

--- a/nexus_motion_planner/test/test_motion_plan_cache.py
+++ b/nexus_motion_planner/test/test_motion_plan_cache.py
@@ -1,0 +1,148 @@
+# Copyright 2023 Johnson & Johnson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import ExecuteProcess
+from launch_pytest.tools import process as process_tools
+from launch_ros.actions import Node
+
+from moveit_configs_utils import MoveItConfigsBuilder
+
+import launch_pytest
+
+import pytest
+import os
+
+# This would have been a gtest, but we need a move_group instance, which
+# requires some parameters loaded and a separate node started.
+
+
+@pytest.fixture
+def moveit_config():
+    return (
+        MoveItConfigsBuilder("moveit_resources_panda")
+        .robot_description(file_path="config/panda.urdf.xacro")
+        .planning_pipelines("ompl", ["ompl"])  # Sadly necessary
+        .trajectory_execution(file_path="config/gripper_moveit_controllers.yaml")
+        .to_moveit_configs()
+    )
+
+
+# We need this so the move_group has something to interact with
+@pytest.fixture
+def robot_fixture(moveit_config):
+    run_move_group_node = Node(
+        package="moveit_ros_move_group",
+        executable="move_group",
+        output="log",
+        parameters=[moveit_config.to_dict()],
+    )
+
+    static_tf = Node(
+        package="tf2_ros",
+        executable="static_transform_publisher",
+        output="log",
+        arguments=["0.0", "0.0", "0.0", "0.0",
+                   "0.0", "0.0", "world", "panda_link0"],
+    )
+
+    robot_state_publisher = Node(
+        package="robot_state_publisher",
+        executable="robot_state_publisher",
+        name="robot_state_publisher",
+        output="log",
+        parameters=[moveit_config.robot_description],
+    )
+
+    # ros2_control using FakeSystem as hardware
+    ros2_controllers_path = os.path.join(
+        get_package_share_directory("moveit_resources_panda_moveit_config"),
+        "config",
+        "ros2_controllers.yaml",
+    )
+    ros2_control_node = Node(
+        package="controller_manager",
+        executable="ros2_control_node",
+        parameters=[moveit_config.robot_description, ros2_controllers_path],
+        output="log",
+    )
+
+    load_controllers = []
+    for controller in [
+        "panda_arm_controller",
+        "panda_hand_controller",
+        "joint_state_broadcaster",
+    ]:
+        load_controllers += [
+            ExecuteProcess(
+                cmd=["ros2 run controller_manager spawner {}".format(
+                    controller)],
+                shell=True,
+                output="log",
+            )
+        ]
+
+    return [
+        run_move_group_node,
+        static_tf,
+        robot_state_publisher,
+        ros2_control_node,
+        *load_controllers
+    ]
+
+
+@pytest.fixture
+def motion_cache_test_runner_node(moveit_config):
+    return Node(
+        package="nexus_motion_planner",
+        executable="test_motion_plan_cache",
+        name="test_motion_plan_cache_node",
+        output="screen",
+        cached_output=True,
+        parameters=[moveit_config.to_dict()]
+    )
+
+
+@launch_pytest.fixture
+def launch_description(motion_cache_test_runner_node, robot_fixture):
+    return LaunchDescription(
+        robot_fixture +
+        [
+            motion_cache_test_runner_node,
+            launch_pytest.actions.ReadyToTest()
+        ]
+    )
+
+
+def validate_stream(expected):
+    def wrapped(output):
+        assert expected in output.splitlines(
+        ), f"Did not get expected: {expected} in output:\n\n{output}"
+    return wrapped
+
+
+@pytest.mark.launch(fixture=launch_description)
+def test_all_tests_pass(motion_cache_test_runner_node, launch_context):
+    # Check no occurrences of [FAIL] in output
+    assert not process_tools.wait_for_output_sync(
+        launch_context,
+        motion_cache_test_runner_node,
+        lambda x: "[FAIL]" in x,
+        timeout=10
+    )
+
+    # Wait for process to end and check for graceful exit
+    yield
+    assert motion_cache_test_runner_node.return_code == 0

--- a/nexus_motion_planner/test/test_request_with_cache.test.py
+++ b/nexus_motion_planner/test/test_request_with_cache.test.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Johnson & Johnson
+# Copyright 2023 Johnson & Johnson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -101,7 +101,7 @@ def generate_test_description():
 
     robot_xacro_file = "irb1300_10_115.xacro"
     moveit_config_file = "abb_irb1300_10_115.srdf.xacro"
-    planner_config_file = "planner_params.yaml"
+    planner_config_file = "planner_params_with_cache.yaml"
 
     moveit_config_package = "abb_irb1300_10_115_moveit_config"
     support_package = "abb_irb1300_support"
@@ -385,6 +385,7 @@ class TestGetMotionPlanService(unittest.TestCase):
 
         motion_planner_server_str = [
             "Planning request accepted",
+            "Inserting plan",
             "Planning request complete!",
         ]
 

--- a/nexus_msgs/nexus_motion_planner_msgs/srv/GetMotionPlan.srv
+++ b/nexus_msgs/nexus_motion_planner_msgs/srv/GetMotionPlan.srv
@@ -52,6 +52,11 @@ string payload
 float64 max_velocity_scaling_factor
 float64 max_acceleration_scaling_factor
 
+# Set to true in order to force the server to use the motion cache as if the
+# cache mode were set to ExecuteReadOnly, regardless of the original setting
+# for this request.
+bool force_cache_mode_execute_read_only
+
 ---
 
 # Motion planning result

--- a/nexus_tree_nodes.xml
+++ b/nexus_tree_nodes.xml
@@ -52,6 +52,7 @@
       <input_port name="scale_speed">An optional fraction [0,1] to scale the acceleraton and speed of the generated trajectory</input_port>
       <input_port name="cartesian">True if a cartesian plan is required</input_port>
       <input_port name="start_constraints">If provided the joint_constraints will be used as the start state of the robot. By default the current state is set as start</input_port>
+      <input_port name="force_cache_mode_execute_read_only">True to force cache mode to ExecuteReadOnly for this request.</input_port>
       <output_port name="result">The generated motion plan</output_port>
     </Action>
 


### PR DESCRIPTION
# WARNING
```
 *   This cache does NOT support collision detection!
 *   Plans will be put into and fetched from the cache IGNORING collision.
 *   If your planning scene is expected to change between cache lookups, do NOT
 *   use this cache, fetched plans are likely to result in collision then.
 *
 *   To handle collisions this class will need to hash the planning scene world
 *   msg (after zeroing out std_msgs/Header timestamps and sequences) and do an
 *   appropriate lookup. (very out of scope)
```

# Description

This PR adds a `MotionPlanCache` class that wraps a `warehouse_ros` database interface.
It is then incorporated into the motion_planning_server.

Features:
- Put and fetch `RobotTrajectory` plans keyed by `MotionPlanRequest` message values
  - This includes ALL joint, position, and orientation constraints!
- Supports fuzzy matching on the start and goal params in the request
- Supports overwriting "worse" plans with "better" plans (this prunes the database and keeps it tidy!)
- Separate caches for separate move groups

Furthermore, because our goals are stated in zero-offset TFs, the cache does a TF lookup and restates them in the database with respect to the workspace frame! (i.e. wrt. base_link.)

I could only test this on sqlite3. I couldn't set up MongoDB on my setup.

Also, while this is not 100% generalizable to all moveit plannable plans, I think this is a good candidate for upstreaming! :tada: 

# Why is this PR so big?
It's not trivial to key the motion plans. This is because there are many factors that go into the plan request, and the fulfilling plan. It should be visible from how I'm handling each factor on review.

I'll attach example requests, and an example generated trajectory. On inspecting those messages, it should be clear that it's not trivial to key them (but I think I managed to do it!)

## Start State (MotionPlanRequest) Variations

<details>
<summary>`is_diff=true`, which requires getting the current state</summary>

```
workspace_parameters:
  header:
    stamp:
      sec: 1695075603
      nanosec: 61941176
    frame_id: "base_link"
  min_corner:
    x: -0.570000
    y: -0.300000
    z: 0.00000
  max_corner:
    x: 0.830000
    y: 0.850000
    z: 1.39000
start_state:
  joint_state:
    header:
      stamp:
        sec: 0
        nanosec: 0
      frame_id: ""
    name: []
    position: []
    velocity: []
    effort: []
  multi_dof_joint_state:
    header:
      stamp:
        sec: 0
        nanosec: 0
      frame_id: ""
    joint_names: []
    transforms: []
    twist: []
    wrench: []
  attached_collision_objects: []
  is_diff: true
goal_constraints:
-
  name: ""
  joint_constraints: []
  position_constraints:
  -
    header:
      stamp:
        sec: 0
        nanosec: 0
      frame_id: "pickup_label_goal_pose"
    link_name: "gripper_link"
    target_point_offset:
      x: 0.00000
      y: 0.00000
      z: 0.00000
    constraint_region:  // (CH3) WE'RE IGNORING THIS
      primitives:
      -
        type: 2
        dimensions:
        - 0.000100000
        polygon:
          points: []
      primitive_poses:
      -
        position:
          x: 0.00000
          y: 0.00000
          z: -0.0100000
        orientation:
          x: 0.00000
          y: 0.00000
          z: 0.00000
          w: 1.00000
      meshes: []
      mesh_poses: []
    weight: 1.00000
  orientation_constraints:
  -
    header:
      stamp:
        sec: 0
        nanosec: 0
      frame_id: "pickup_label_goal_pose"
    orientation:
      x: 0.00000
      y: 0.00000
      z: 0.00000
      w: 1.00000
    link_name: "gripper_link"
    absolute_x_axis_tolerance: 0.000100000
    absolute_y_axis_tolerance: 0.000100000
    absolute_z_axis_tolerance: 0.000100000
    parameterization: 0
    weight: 1.00000
  visibility_constraints: []
path_constraints:
  name: ""
  joint_constraints: []
  position_constraints: []
  orientation_constraints: []
  visibility_constraints: []
trajectory_constraints:
  constraints: []
reference_trajectories: []
pipeline_id: ""
planner_id: ""
group_name: "manipulator"
num_planning_attempts: 1
allowed_planning_time: 5.00000
max_velocity_scaling_factor: 0.300000
max_acceleration_scaling_factor: 0.300000
cartesian_speed_end_effector_link: ""
max_cartesian_speed: 0.00000
```
</details>

<details>
<summary>Or if joint states were explicitly provided as start</summary>

```
workspace_parameters:
  header:
    stamp:
      sec: 1695079404
      nanosec: 4589339
    frame_id: "base_link"
  min_corner:
    x: -0.570000
    y: -0.300000
    z: 0.00000
  max_corner:
    x: 0.830000
    y: 0.850000
    z: 1.39000
start_state:
  joint_state:
    header:
      stamp:
        sec: 0
        nanosec: 0
      frame_id: "base_link"
    name:
    - "joint_1"
    - "joint_2"
    - "joint_3"
    - "joint_4"
    - "joint_5"
    - "joint_6"
    position:
    - 0.00000
    - 0.00000
    - 0.00000
    - 0.00000
    - 0.00000
    - 0.00000
    velocity: []
    effort: []
  multi_dof_joint_state:
    header:
      stamp:
        sec: 0
        nanosec: 0
      frame_id: "base_link"
    joint_names: []
    transforms: []
    twist: []
    wrench: []
  attached_collision_objects: []
  is_diff: false
goal_constraints:
-
  name: ""
  joint_constraints: []
  position_constraints:
  -
    header:
      stamp:
        sec: 0
        nanosec: 0
      frame_id: "pickup_label_goal_pose"
    link_name: "gripper_link"
    target_point_offset:
      x: 0.00000
      y: 0.00000
      z: 0.00000
    constraint_region:
      primitives:
      -
        type: 2
        dimensions:
        - 0.000100000
        polygon:
          points: []
      primitive_poses:
      -
        position:
          x: 0.00000
          y: 0.00000
          z: -0.0100000
        orientation:
          x: 0.00000
          y: 0.00000
          z: 0.00000
          w: 1.00000
      meshes: []
      mesh_poses: []
    weight: 1.00000
  orientation_constraints:
  -
    header:
      stamp:
        sec: 0
        nanosec: 0
      frame_id: "pickup_label_goal_pose"
    orientation:
      x: 0.00000
      y: 0.00000
      z: 0.00000
      w: 1.00000
    link_name: "gripper_link"
    absolute_x_axis_tolerance: 0.000100000
    absolute_y_axis_tolerance: 0.000100000
    absolute_z_axis_tolerance: 0.000100000
    parameterization: 0
    weight: 1.00000
  visibility_constraints: []
path_constraints:
  name: ""
  joint_constraints: []
  position_constraints: []
  orientation_constraints: []
  visibility_constraints: []
trajectory_constraints:
  constraints: []
reference_trajectories: []
pipeline_id: ""
planner_id: ""
group_name: "manipulator"
num_planning_attempts: 1
allowed_planning_time: 5.00000
max_velocity_scaling_factor: 0.300000
max_acceleration_scaling_factor: 0.300000
cartesian_speed_end_effector_link: ""
max_cartesian_speed: 0.00000
```
</details>

Notice for both cases, the goal is stated in terms of a TF frame (which can change.)
The motion plan cache restates the goal in terms of an x, y, z and orientation offset from the planning frame (which should not change.)

Planning frame is consequently part of the key for cache lookups.

## Generated Plan Example

<details>

```
joint_trajectory:
  header:
    stamp:
      sec: 0
      nanosec: 0
    frame_id: "base_link"
  joint_names:
  - "joint_1"
  - "joint_2"
  - "joint_3"
  - "joint_4"
  - "joint_5"
  - "joint_6"
  points:
  -
    positions:
    - 0.548301
    - 0.835924
    - 0.543629
    - -0.000849880
    - 0.191294
    - -1.02156
    velocities:
    - 0.0100000
    - 0.000238418
    - 0.00142367
    - -0.00630237
    - -0.00170240
    - -0.00574253
    accelerations:
    - 10.0000
    - 0.238418
    - 1.42367
    - -6.30237
    - -1.70240
    - -5.74253
    effort: []
    time_from_start:
      sec: 0
      nanosec: 0
  -
    positions:
    - 0.598300
    - 0.837116
    - 0.550747
    - -0.0323615
    - 0.182782
    - -1.05027
    velocities:
    - 1.00681
    - 0.0240042
    - 0.143337
    - -0.634529
    - -0.171400
    - -0.578163
    accelerations:
    - 10.0000
    - 0.238418
    - 1.42367
    - -6.30237
    - -1.70240
    - -5.74253
    effort: []
    time_from_start:
      sec: 0
      nanosec: 100000000
  -
    positions:
    - 0.748297
    - 0.840692
    - 0.572102
    - -0.126895
    - 0.157246
    - -1.13641
    velocities:
    - 2.00296
    - 0.0477543
    - 0.285157
    - -1.26234
    - -0.340985
    - -1.15021
    accelerations:
    - 10.0000
    - 0.238418
    - 1.42367
    - -6.30237
    - -1.70240
    - -5.74253
    effort: []
    time_from_start:
      sec: 0
      nanosec: 200000000
  -
    positions:
    - 0.987439
    - 0.846394
    - 0.606148
    - -0.277611
    - 0.116535
    - -1.27373
    velocities:
    - 2.34000
    - 0.0557899
    - 0.333140
    - -1.47476
    - -0.398362
    - -1.34375
    accelerations:
    - -10.0000
    - -0.238418
    - -1.42367
    - 6.30237
    - 1.70240
    - 5.74253
    effort: []
    time_from_start:
      sec: 0
      nanosec: 300000000
  -
    positions:
    - 1.17155
    - 0.850783
    - 0.632359
    - -0.393642
    - 0.0851921
    - -1.37946
    velocities:
    - 1.34000
    - 0.0319480
    - 0.190772
    - -0.844518
    - -0.228122
    - -0.769498
    accelerations:
    - -10.0000
    - -0.238418
    - -1.42367
    - 6.30237
    - 1.70240
    - 5.74253
    effort: []
    time_from_start:
      sec: 0
      nanosec: 400000000
  -
    positions:
    - 1.25565
    - 0.852788
    - 0.644333
    - -0.446650
    - 0.0708737
    - -1.42776
    velocities:
    - 0.340000
    - 0.00810622
    - 0.0484049
    - -0.214281
    - -0.0578817
    - -0.195246
    accelerations:
    - -10.0000
    - -0.238418
    - -1.42367
    - 6.30237
    - 1.70240
    - 5.74253
    effort: []
    time_from_start:
      sec: 0
      nanosec: 500000000
  -
    positions:
    - 1.26147
    - 0.852927
    - 0.645161
    - -0.450315
    - 0.0698835
    - -1.43110
    velocities:
    - 3.00625e-16
    - 7.16745e-18
    - 4.27992e-17
    - -1.89465e-16
    - -5.11785e-17
    - -1.72635e-16
    accelerations:
    - -10.0000
    - -0.238418
    - -1.42367
    - 6.30237
    - 1.70240
    - 5.74253
    effort: []
    time_from_start:
      sec: 0
      nanosec: 534110678
multi_dof_joint_trajectory:
  header:
    stamp:
      sec: 0
      nanosec: 0
    frame_id: ""
  joint_names: []
  points: []
```

</details>

## Insight
Notice that keying them requires considering many things, like the varying number of joints, joint constraints; orientation constraints; position constraints; planning frames, etc.

I picked what I think is a good set that covers most of our cases. What I am explicitly not supporting is stated below.

# Images

## Cache hits and pushes!
![image](https://github.com/OpenSourceRobotics/nexus/assets/20265670/2583c5ef-f0c7-4b15-8b51-c89888914a25)

## A view of the schema
![image](https://github.com/OpenSourceRobotics/nexus/assets/20265670/f2c0afd7-251c-4859-90c9-5453d6cd8f08)

## With database collections for each move group
![image](https://github.com/OpenSourceRobotics/nexus/assets/20265670/509ab773-c030-4345-9b06-daa4cb1b2ce2)

## Populated Entries
![image](https://github.com/OpenSourceRobotics/nexus/assets/20265670/3e35fe64-3851-4f9e-acdf-37d5935c8507)

# Notes
Does not support:
- Constraint regions
- Collision objects
- Cartesian planning (introduced in #18)
- Velocity/Acceleration constraints
- Obstacles in the planning scene

It also only partially handles matching in cases where constraints get jumbled up in order. (But this really shouldn't happen, I think.)

# TODO
- [x] Retrofit the launch files (but what path do I use for the db?)
- [ ] Test on physical setup. I was only able to test by spoofing "execute_trajectory=True" and not actually executing the trajectory.
  - The fuzzy matching parameters should be tuned depending on how much precision we want. (I currently set them to about ~0.5 degrees per joint for the start, and 1mm goal offsets in all axes.)
- [ ] Unit tests??
- [ ] Benchmark cache time vs planning times?