### PR TITLE
Pass same NodeOptions to planner's internal node

### DIFF
--- a/nexus_motion_planner/CMakeLists.txt
+++ b/nexus_motion_planner/CMakeLists.txt
@@ -33,6 +33,7 @@ set (motion_planner_server_dependencies
 )
 
 set (test_request_dependencies
+  moveit_msgs
   nexus_endpoints
   geometry_msgs
   rclcpp

--- a/nexus_motion_planner/launch/demo_planner_server.launch.py
+++ b/nexus_motion_planner/launch/demo_planner_server.launch.py
@@ -197,7 +197,7 @@ def launch_setup(context, *args, **kwargs):
         executable="static_transform_publisher",
         name="motion_planner_static_transform_publisher_base_link_t_item",
         output="log",
-        arguments=["0.3", "0.2", "0.1", "0.0", "0.0", "0.0", "base_link", "item"],
+        arguments=["0.6", "0.2", "0.5", "3.14", "0.0", "3.14", "base_link", "item"],
         condition=IfCondition(publish_item),
     )
 

--- a/nexus_motion_planner/src/motion_planner_server.cpp
+++ b/nexus_motion_planner/src/motion_planner_server.cpp
@@ -20,17 +20,14 @@ MotionPlannerServer::MotionPlannerServer(const rclcpp::NodeOptions& options)
 {
   RCLCPP_INFO(this->get_logger(), "Motion Planner Server is running...");
 
-  auto internal_node_options = rclcpp::NodeOptions();
-  internal_node_options.automatically_declare_parameters_from_overrides(true);
-  internal_node_options.use_global_arguments(false);
   _internal_node = std::make_shared<rclcpp::Node>(
-    "motion_planner_server_internal_node", internal_node_options);
+    "motion_planner_server_internal_node", options);
   _spin_thread = std::thread(
-    [this]()
+    [node = _internal_node]()
     {
       while (rclcpp::ok())
       {
-        rclcpp::spin_some(_internal_node);
+        rclcpp::spin_some(node);
       }
     });
 
@@ -69,30 +66,6 @@ MotionPlannerServer::MotionPlannerServer(const rclcpp::NodeOptions& options)
       this->declare_parameter(name + ".group_name", name + ".manipulator") :
       this->declare_parameter("default_group_name", "manipulator");
     _group_names.insert({name, std::move(group_name)});
-
-    const std::string description_param_name = _use_namespace ?
-      name + ".robot_description" : "robot_description";
-    const auto description_param =
-      this->declare_parameter(
-      description_param_name,
-      rclcpp::ParameterType::PARAMETER_STRING);
-
-    // Push robot_description parameter to internal node
-    _internal_node->declare_parameter(
-      description_param_name,
-      description_param);
-
-    const std::string description_semantic_param_name = _use_namespace ?
-      name + ".robot_description_semantic" : "robot_description_semantic";
-    const auto description_semantic_param =
-      this->declare_parameter(
-      description_semantic_param_name,
-      rclcpp::ParameterType::PARAMETER_STRING);
-
-    // Push robot_description_semantic parameter to internal node
-    _internal_node->declare_parameter(
-      description_semantic_param_name,
-      description_semantic_param);
 
   }
   RCLCPP_INFO(


### PR DESCRIPTION
The `nexus_motion_planner` spins an internal `rclcpp::Node::SharedPtr` since `moveit's` `move_group_interface` API does is not compatible with a `LifecycleNode`.  Looking at the implementation, we were trying to declare some of the move_group related parameters in the LifecycleNode and then "forward" the declaration to the internal node. However there is no need to do this since we can just pass the same `NodeOptions` to the internal node which will also pass the `arguments` to the ROS 2 node which the move_group_interface will rely on to declare relevant parameters. 

Without this fix, I was seeing a couple of warning in the terminal from not declaring certain essential moveit parameters as arguments were missing. But now by passing the same options, the internal node has access to the same arguments as the parent and can declare all required moveit params.

Also fix linking error with running the test executable.