### PR TITLE
Fix and add motion planner server tests

### DIFF
--- a/.github/workflows/nexus_integration_tests.yaml
+++ b/.github/workflows/nexus_integration_tests.yaml
@@ -40,6 +40,8 @@ jobs:
         rosdep update
         rosdep install --from-paths . -yir
     - name: build
-      run: /ros_entrypoint.sh colcon build --packages-up-to nexus_integration_tests --mixin release lld --cmake-args -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-    - name: test
+      run: /ros_entrypoint.sh colcon build --packages-up-to nexus_integration_tests nexus_motion_planner --mixin release lld --cmake-args -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+    - name: Test - Unit Tests
+      run: . ./install/setup.bash && RMW_IMPLEMENTATION=rmw_cyclonedds_cpp /ros_entrypoint.sh colcon test --packages-select nexus_motion_planner --event-handlers=console_direct+
+    - name: Test - Integration Test
       run: . ./install/setup.bash && cd nexus_integration_tests && RMW_IMPLEMENTATION=rmw_cyclonedds_cpp /ros_entrypoint.sh python3 -m unittest

--- a/nexus_motion_planner/CMakeLists.txt
+++ b/nexus_motion_planner/CMakeLists.txt
@@ -105,11 +105,17 @@ if(BUILD_TESTING)
    WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
   )
 
-  # TODO(YV): Fix these tests.
-  # add_launch_test(
-  #   test/test_request.test.py
-  #   TIMEOUT 60
-  # )
+  # Motion planner server test with cache mode unset
+  add_launch_test(
+    test/test_request.test.py
+    TIMEOUT 60
+  )
+
+  # Motion planner server test with cache mode set (so it uses the cache)
+  add_launch_test(
+    test/test_request_with_cache.test.py
+    TIMEOUT 60
+  )
 endif()
 
 ament_export_dependencies(${motion_planner_server_dependencies} ${motion_plan_cache_dependencies})

--- a/nexus_motion_planner/config/planner_params.yaml
+++ b/nexus_motion_planner/config/planner_params.yaml
@@ -42,17 +42,3 @@ motion_planner_server:
     workspace_max_z: 1.0
     # The seconds within which the current robot state should be valid.
     get_state_wait_seconds: 0.01
-    # Namespaced parameters for each robot when use_namespace is true.
-    # Is important to ensure move_group, robot_state_publisher and
-    # joint_state broadcaster all have the same namespace.
-    # Note: If use_namespace is false, pass these parameters directly.
-    abb_irb1300:
-      robot_description: ""
-      robot_description_semantic: ""
-      group_name: "manipulator"
-      # Group specific kinematic properties.
-      manipulator:
-        kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
-        kinematics_solver_search_resolution: 0.005
-        kinematics_solver_timeout: 0.005
-        kinematics_solver_attempts: 3

--- a/nexus_motion_planner/config/planner_params_with_cache.yaml
+++ b/nexus_motion_planner/config/planner_params_with_cache.yaml
@@ -1,0 +1,76 @@
+motion_planner_server:
+  ros__parameters:
+    # List of robots to generate motion plans for
+    manipulators: ["abb_irb1300"]
+    # The default moveit group for each manipulator
+    default_group_name: "manipulator"
+    # Seconds to wait to connect to an action or service server
+    timeout_duration: 5
+    # Configure the planner_server to query motion plans directly from a move_group
+    # node that is running by initializing a move_group_interface.
+    # When set to false, the planner_server will initialize planning pipelines
+    # to directly compute plans but this has not been implemented yet.
+    use_move_group_interfaces: true
+    # When planning for multiple robots, set this to true.
+    use_namespace: false
+    # Tolerance for goal position.
+    goal_tolerance: 0.005
+    # Maximum seconds to generate a plan.
+    planning_time: 1.0
+    # Maximum number of replanning attempts
+    replan_attempts: 10
+    # If true, the cartesian interpolator will check for collisions.
+    collision_aware_cartesian_path: false
+    # The value of the max_step parameter used in cartesian interpolation.
+    cartesian_max_step: 0.001
+    # The value of the jump_threshold parameter used in cartesian interpolation.
+    cartesian_jump_threshold: 0.0
+    # Set true if trajectory should be executed after a plan is generated.
+    # The execution is a blocking event.
+    execute_trajectory: false
+    # The min_x of workspace bounding box.
+    workspace_min_x: -1.0
+    # The min_y of workspace bounding box.
+    workspace_min_y: -1.0
+    # The min_z of workspace bounding box.
+    workspace_min_z: -1.0
+    # The max_x of workspace bounding box.
+    workspace_max_x: 1.0
+    # The max_y of workspace bounding box.
+    workspace_max_y: 1.0
+      # The max_z of workspace bounding box.
+    workspace_max_z: 1.0
+    # The seconds within which the current robot state should be valid.
+    get_state_wait_seconds: 0.01
+
+    ## Motion Plan Cache Parameters
+    # Planner database mode. Valid values:
+    #   - Unset: Always plan. No caching.
+    #   - TrainingOverwrite: Always plan, overwriting existing cache plans if better plan was found.
+    #   - TrainingAppendOnly: Always plan, append to cache if better plan was found (no overwriting).
+    #   - ExecuteBestEffort: Prioritize cached plans. Only plan if no cached plans found.
+    #   - ExecuteReadOnly: Only use cached plans. Fail if no cached plans found.
+    planner_database_mode: "TrainingOverwrite"
+    # Database type and location
+    cache_db_plugin: "warehouse_ros_sqlite::DatabaseConnection"
+    cache_db_host: ":memory:"
+    cache_db_port: 0  # Isn't used for SQLite3
+
+    # The cache keys cache entries on certain properties of the motion plan request's
+    # starting joint state, goal constraints, and more.
+
+    # For float comparisons, what tolerance counts as an exact match (to prevent floating point precision errors)
+    cache_exact_match_tolerance: 0.001  # ~0.05 degrees per joint
+    # Query range thresholds for matching attributes of the starting robot state for cache hits.
+    # This typically applies to joint states, per joint, in radians
+    #
+    # It should be acceptable to be more lenient on the start state, because the robot will be commanded
+    # to go to the first trajectory point from it's current start state.
+    cache_start_match_tolerance: 0.025
+    # Query range thresholds for matching attributes of the requested planning goals for cache hits.
+    # This typically applies to the x, y, z coordinates of the goal pose, in metres
+    # And also the individual quaternion components of the goal orientation
+    #
+    # Goal tolerances should be more strict so the end point of the robot remains consistent between
+    # the fetched plan and the desired goal.
+    cache_goal_match_tolerance: 0.001

--- a/nexus_motion_planner/package.xml
+++ b/nexus_motion_planner/package.xml
@@ -37,6 +37,8 @@
   <test_depend>moveit_resources</test_depend>
   <test_depend>python3-pytest</test_depend>
   <test_depend>rmf_utils</test_depend>
+  <test_depend>robot_state_publisher</test_depend>
+  <test_depend>ros2_control</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/nexus_motion_planner/test/test_request_with_cache.test.py
+++ b/nexus_motion_planner/test/test_request_with_cache.test.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Johnson & Johnson
+# Copyright 2023 Johnson & Johnson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -101,7 +101,7 @@ def generate_test_description():
 
     robot_xacro_file = "irb1300_10_115.xacro"
     moveit_config_file = "abb_irb1300_10_115.srdf.xacro"
-    planner_config_file = "planner_params.yaml"
+    planner_config_file = "planner_params_with_cache.yaml"
 
     moveit_config_package = "abb_irb1300_10_115_moveit_config"
     support_package = "abb_irb1300_support"
@@ -385,6 +385,7 @@ class TestGetMotionPlanService(unittest.TestCase):
 
         motion_planner_server_str = [
             "Planning request accepted",
+            "Inserting plan",
             "Planning request complete!",
         ]
 


### PR DESCRIPTION
Builds on top of:
- https://github.com/osrf/nexus/pull/16

I uncommented the old launch test, and discovered it was passing.

Then I tried adding a test for the motion plan cache, and had it fail because we need access to the robot joint state.

Turns out the old tests weren't loading a ros2_control controller, so I fixed it (maybe that's what broke in the first place?)

After building, test with:
```
clear && colcon test --packages-select nexus_motion_planner --event-handlers=console_direct+
```