### PR TITLE
Migrate to ros2dds bridge

### DIFF
--- a/nexus_integration_tests/config/zenoh/nexus_network_config.yaml
+++ b/nexus_integration_tests/config/zenoh/nexus_network_config.yaml
@@ -2,32 +2,68 @@
 # Use 'client' when there is an available Zenoh router, otherwise
 # use 'peer' for a distributed system.
 mode: peer
-# When true, discovery info is forwarded to the remote plugins/bridges
-forward_discovery: false
 # When true, activates a REST API used to administer Zenoh Bridge configurations
 enable_rest_api: true
-# Additional endpoints to allow, these could be endpoints not defined in REDF but are necessary for lifecycle transitions
-add_allowed_endpoints: ["/list_workcells", "/.*/workcell_state", "/.*/is_task_doable", "/.*/request", "/.*/queue_task", "/.*/remove_pending_task", "/register_workcell", "/register_transporter", ".*/available", ".*/transport", "/estop", "/.*/pause", "/.*/get_state", "/.*/change_state", "/.*/signal"]
 
 system_orchestrators:
-  - ros_namespace: system_orchestrator # ROS Namespace of the endpoints
+  - namespace: system_orchestrator # ROS Namespace of the endpoints
     # ROS Domain ID
-    domain_id: 14
+    domain_id: 0
     # Listening TCP Address of Zenoh bridge
     tcp_listen: ["0.0.0.0:7447"]
     # HTTP Port for the REST API
     rest_api_http_port: 8000
+    allow:
+      publishers: []
+      # TODO(luca) check if we need estop
+      subscribers: ["/estop", "/.*/workcell_state"]
+      service_servers: ["/list_workcells", "/register_workcell", "/register_transporter"]
+      # TODO(luca) check if transporter needs available endpoint
+      service_clients: ["/.*/queue_task", "/.*/remove_pending_task", "/.*/pause", "/.*/signal", "/.*/get_state", "/.*/change_state", "/.*/is_task_doable"]
+      action_servers: []
+      # TODO(luca) check if we really need transporter client
+      action_clients: ["/.*/request", "/.*/transport"]
+    queries_timeout:
+      default: 600.0
+
 
 workcell_orchestrators:
-  - ros_namespace: workcell_1
-    domain_id: 15
+  - namespace: workcell_1
+    domain_id: 1
     tcp_connect: ["0.0.0.0:7447"]
     rest_api_http_port: 8001
-  - ros_namespace: workcell_2
-    domain_id: 16
+    allow:
+      publishers: ["/workcell_1/workcell_state"]
+      subscribers: []
+      service_servers: ["/workcell_1/is_task_doable", "/workcell_1/queue_task", "/workcell_1/remove_pending_task", "/workcell_1/get_state", "/workcell_1/change_state", "/workcell_1/signal", "/workcell_1/pause"]
+      service_clients: ["/register_workcell"]
+      action_servers: ["/workcell_1/request"]
+      action_clients: []
+    queries_timeout:
+      default: 600.0
+  - namespace: workcell_2
+    domain_id: 2
     tcp_connect: ["0.0.0.0:7447"]
     rest_api_http_port: 8002
-  - ros_namespace: workcell_3
-    domain_id: 17
+    allow:
+      publishers: ["/workcell_2/workcell_state"]
+      subscribers: []
+      service_servers: ["/workcell_2/is_task_doable", "/workcell_2/queue_task", "/workcell_2/remove_pending_task", "/workcell_2/get_state", "/workcell_2/change_state", "/workcell_2/signal", "/workcell_2/pause"]
+      service_clients: ["/register_workcell"]
+      action_servers: ["/workcell_2/request"]
+      action_clients: []
+    queries_timeout:
+      default: 600.0
+  - namespace: workcell_3
+    domain_id: 3
     tcp_connect: ["0.0.0.0:7447"]
     rest_api_http_port: 8003
+    allow:
+      publishers: ["workcell_3/workcell_state"]
+      subscribers: []
+      service_servers: ["workcell_3/is_task_doable", "workcell_3/queue_task", "workcell_3/remove_pending_task", "workcell_3/get_state", "workcell_3/change_state"]
+      service_clients: ["/register_workcell"]
+      action_servers: ["workcell_3/request"]
+      action_clients: []
+    queries_timeout:
+      default: 600.0

--- a/nexus_integration_tests/launch/zenoh_bridge.launch.py
+++ b/nexus_integration_tests/launch/zenoh_bridge.launch.py
@@ -40,7 +40,7 @@ def launch_setup(context, *args, **kwargs):
 
     cmd = [
         ExecutableInPackage(
-            executable="zenoh_bridge_dds",
+            executable="zenoh_bridge_ros2dds",
             package="nexus_zenoh_bridge_dds_vendor",
         ),
         "--config",

--- a/nexus_network_configuration/schemas/nexus_network_schema.json
+++ b/nexus_network_configuration/schemas/nexus_network_schema.json
@@ -6,9 +6,7 @@
   "type": "object",
   "required": [
     "mode",
-    "forward_discovery",
     "enable_rest_api",
-    "add_allowed_endpoints",
     "system_orchestrators",
     "workcell_orchestrators"
   ],
@@ -18,17 +16,9 @@
       "type": "string",
       "enum": ["peer", "client"]
     },
-    "forward_discovery": {
-      "description": "When true, discovery info is forwarded to the remote plugins/bridges",
-      "type": "boolean"
-    },
     "enable_rest_api":{
       "description": "When true, activates a REST API used to administer Zenoh Bridge configurations",
       "type": "boolean"
-    },
-    "add_allowed_endpoints":{
-      "description": "Additional endpoints to allow, these could be endpoints not defined in REDF but are necessary for lifecycle transitions",
-      "type": "array"
     },
     "system_orchestrators": {
       "type": "array",
@@ -41,12 +31,45 @@
   },
 
   "$defs": {
+    "queries_timeout": {
+      "description": "Timeout parameters for Zenoh queries",
+      "type": "object",
+      "properties": {
+        "default": {
+          "type": "number"
+        }
+      }
+    },
+    "allow": {
+      "description": "Additional endpoints to allow, these could be endpoints not defined in REDF but are necessary for lifecycle transitions",
+      "type": "object",
+      "properties": {
+        "subscribers": {
+          "type": "array"
+        },
+        "publishers": {
+          "type": "array"
+        },
+        "service_servers": {
+          "type": "array"
+        },
+        "service_clients": {
+          "type": "array"
+        },
+        "action_servers": {
+          "type": "array"
+        },
+        "action_clients": {
+          "type": "array"
+        }
+      }
+    },
     "system_orchestrator_unit": {
       "type": "object",
-      "required": ["ros_namespace", "domain_id", "tcp_listen"],
+      "required": ["namespace", "domain_id", "tcp_listen"],
       "properties": {
-        "ros_namespace":{
-          "$ref": "#/$defs/ros_namespace"
+        "namespace":{
+          "$ref": "#/$defs/namespace"
         },
         "domain_id":{
           "$ref": "#/$defs/domain_id"
@@ -56,15 +79,21 @@
         },
         "rest_api_http_port":{
           "$ref": "#/$defs/rest_api_http_port"
+        },
+        "allow":{
+          "$ref": "#/$defs/allow"
+        },
+        "queries_timeout":{
+          "$ref": "#/$defs/queries_timeout"
         }
       }
     },
     "workcell_orchestrator_unit": {
       "type": "object",
-      "required": ["ros_namespace", "domain_id", "tcp_connect"],
+      "required": ["namespace", "domain_id", "tcp_connect"],
       "properties": {
-        "ros_namespace":{
-          "$ref": "#/$defs/ros_namespace"
+        "namespace":{
+          "$ref": "#/$defs/namespace"
         },
         "domain_id":{
           "$ref": "#/$defs/domain_id"
@@ -74,10 +103,16 @@
         },
         "rest_api_http_port":{
           "$ref": "#/$defs/rest_api_http_port"
+        },
+        "allow":{
+          "$ref": "#/$defs/allow"
+        },
+        "queries_timeout":{
+          "$ref": "#/$defs/queries_timeout"
         }
       }
     },
-    "ros_namespace":{
+    "namespace":{
       "description": "ROS Namespace of the endpoints",
       "type": "string"
     },
@@ -85,7 +120,7 @@
       "description": "ROS Domain ID",
       "type": "integer",
       "minimum": 0,
-      "maxmimum": 232
+      "maximum": 232
     },
     "tcp_connect":{
       "description": "TCP Address of system orchestrator Zenoh bridge",
@@ -99,7 +134,7 @@
       "description": "HTTP Port for the REST API",
       "type": "integer",
       "minimum": 0,
-      "maxmimum": 65535
+      "maximum": 65535
     }
   }
 }

--- a/nexus_zenoh_bridge_dds_vendor/CMakeLists.txt
+++ b/nexus_zenoh_bridge_dds_vendor/CMakeLists.txt
@@ -11,14 +11,14 @@ find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_vendor_package REQUIRED)
 
 ament_vendor(zeno_bridge_dds_vendor
-  VCS_URL https://github.com/eclipse-zenoh/zenoh-plugin-dds.git
+  VCS_URL https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds.git
   VCS_VERSION 1.0.2
 )
 
 # TODO(sloretz) make a nice way to get this path from ament_vendor
 set(INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/zeno_bridge_dds_vendor-prefix/install")
 install(
-  DIRECTORY "${INSTALL_DIR}/lib/zenoh_bridge_dds/"
+  DIRECTORY "${INSTALL_DIR}/lib/zenoh_bridge_ros2dds/"
   DESTINATION "lib/${PROJECT_NAME}"
   USE_SOURCE_PERMISSIONS
 )

--- a/nexus_zenoh_bridge_dds_vendor/CMakeLists.txt
+++ b/nexus_zenoh_bridge_dds_vendor/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(ament_cmake_vendor_package REQUIRED)
 
 ament_vendor(zeno_bridge_dds_vendor
   VCS_URL https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds.git
-  VCS_VERSION 1.0.4
+  VCS_VERSION 1.0.2
 )
 
 # TODO(sloretz) make a nice way to get this path from ament_vendor

--- a/nexus_zenoh_bridge_dds_vendor/CMakeLists.txt
+++ b/nexus_zenoh_bridge_dds_vendor/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(ament_cmake_vendor_package REQUIRED)
 
 ament_vendor(zeno_bridge_dds_vendor
   VCS_URL https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds.git
-  VCS_VERSION 1.0.2
+  VCS_VERSION 1.0.4
 )
 
 # TODO(sloretz) make a nice way to get this path from ament_vendor

--- a/nexus_zenoh_bridge_dds_vendor/CMakeLists.txt
+++ b/nexus_zenoh_bridge_dds_vendor/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(ament_cmake_vendor_package REQUIRED)
 
 ament_vendor(zeno_bridge_dds_vendor
   VCS_URL https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds.git
-  VCS_VERSION 1.0.2
+  VCS_VERSION 1.0.3
 )
 
 # TODO(sloretz) make a nice way to get this path from ament_vendor


### PR DESCRIPTION
Closes #17.

This seems to work but required a fair bit of changes in the `nexus_network_configuration` package, so we should probably rethink what that package does and how.

Specifically, it had a builtin support for generating configs from redf, but it actually didn't and just used hardcoded endpoints [here](https://github.com/osrf/nexus/blob/0741639171413cd077fb7862b85396210cc35bcb/nexus_integration_tests/config/zenoh/nexus_network_config.yaml#L10).
Furthermore, while with the `dds` plugin we can just specify endpoints as strings, the `ros2dds` plugin requires us to clearly say whether each substring is a publisher, subscriber, service server, service client, action server or action client.
The way I approached it in this PR is the same as the previous PR, [updating the config file](https://github.com/osrf/nexus/blob/ed94ad7f987ef516ee583423a3d80cb71ddbf68d/nexus_integration_tests/config/zenoh/nexus_network_config.yaml#L16-L27) accordingly, however there are a few important changes to consider

### Redf compatibility

`redf` does not have a way to specify for each topic / service etc. which nodes can publish and which can subscribe, so the only way to include `redf` config in its current implementation would be to allow each entity to be both, which breaks the isolation a bit since (for example), we currently do:

```
# System orchestrator
    allow:
      service_servers: [[...] "/register_workcell"]

# Workcell
    allow:
      service_clients: ["/register_workcell"]
```

Allowing both would mean _technically_ allowing a rogue workcell to advertise a `/register_workcell` client which could create a lot of trouble in the system.
Note however that this is also an issue in the current implementation.

Because there was no usage of `redf` for network configuration I couldn't test it and whether it worked or not before I'm fairly sure it will stop working with this PR.

### Queries timeout

The `ros2dds` bridge adds a concept of timeout for a query. They can be pretty [granular](https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds/blob/329d7cf34331e430e7f8f2d0a870225ce608a8d9/DEFAULT_CONFIG.json5#L104-L125) but the main issue is that they also apply to actions so if an action was to take longer than the specified value it would fail.
I set it to 10 minutes as a default, but this should probably be double checked (increased? made more granular?).

### Namespaces

Sadly, while the ros2dds bridge supports namespaces, they currently [also apply them to global topics](https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds/blob/329d7cf34331e430e7f8f2d0a870225ce608a8d9/DEFAULT_CONFIG.json5#L18-L26). This means that if we set a bridge with namespace `workcell_1` and asked it to allow a subscription to `/chatter` it would silently only allow `/workcell_1/chatter`. This makes it pretty painful because workcells need to access global services to register, so we can't rely on namespaces and have to add them manually to each workcell configuration.

### Warning spam

Last but not least, running the `ros2dds` bridge results in a lot of warnings being printed, they seem to be harmless but are still very noisy. An [upstream issue](https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds/issues/290) has been opened and acknowledged by Zettascale.