### PR TITLE
Introduce a common TaskRemapper with wildcard support

### DIFF
--- a/nexus_common/CMakeLists.txt
+++ b/nexus_common/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(${PROJECT_NAME} SHARED
   src/node_thread.cpp
   src/node_utils.cpp
   src/pausable_sequence.cpp
+  src/task_remapper.cpp
 )
 GENERATE_EXPORT_HEADER(${PROJECT_NAME}
   EXPORT_FILE_NAME "include/nexus_common_export.hpp"
@@ -130,6 +131,7 @@ if(BUILD_TESTING)
   )
   nexus_add_test(logging_test src/logging_test.cpp)
   nexus_add_test(sync_ros_client_test src/sync_ros_client_test.cpp)
+  nexus_add_test(task_remapper_test src/task_remapper_test.cpp)
 endif()
 
 ament_export_targets(${PROJECT_NAME})

--- a/nexus_common/include/nexus_common/task_remapper.hpp
+++ b/nexus_common/include/nexus_common/task_remapper.hpp
@@ -22,6 +22,9 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#include <optional>
+#include <string>
+
 namespace nexus::common {
 
 /**
@@ -37,8 +40,9 @@ public:
 
   /*
    * Remaps, if necessary, the input task
+   * Returns a value if the task was remapped, std::nullopt otherwise
    */
-  std::string remap(const std::string& task) const;
+  std::optional<std::string> remap(const std::string& task) const;
 
 private:
   // If present, match every incoming task to the target task

--- a/nexus_common/include/nexus_common/task_remapper.hpp
+++ b/nexus_common/include/nexus_common/task_remapper.hpp
@@ -22,6 +22,8 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#include <yaml-cpp/yaml.h>
+
 #include <optional>
 #include <string>
 
@@ -34,9 +36,18 @@ class NEXUS_COMMON_EXPORT TaskRemapper
 {
 public:
   /*
-   * Initialize the remapper with the value of a ROS parameter containing a YAML
+   * Initialize the remapper with the value of a ROS parameter containing a YAML.
+   *
+   * The YAML should have a sequence of key:value types where the key is the task to
+   * remap to, and the value is a list of tasks to remap to the key.
+   * For example:
+   *
+   *    pick_and_place: [pick, place]
+   *    a_and_b: [a, b]
+   *
+   * Will remap "pick" or "place" to "pick_and_place", "a" and "b" to "a_and_b"
    */
-  TaskRemapper(const std::string& param);
+  TaskRemapper(const YAML::Node& remaps);
 
   /*
    * Remaps, if necessary, the input task

--- a/nexus_common/include/nexus_common/task_remapper.hpp
+++ b/nexus_common/include/nexus_common/task_remapper.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Open Source Robotics Foundation
+ * Copyright (C) 2025 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nexus_common/include/nexus_common/task_remapper.hpp
+++ b/nexus_common/include/nexus_common/task_remapper.hpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2024 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef NEXUS_COMMON__TASK_REMAPPER_HPP
+#define NEXUS_COMMON__TASK_REMAPPER_HPP
+
+#include "nexus_common_export.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+namespace nexus::common {
+
+/**
+ * Provides task remapping capability
+ */
+class NEXUS_COMMON_EXPORT TaskRemapper
+{
+public:
+  /*
+   * Initialize the remapper with the value of a ROS parameter containing a YAML
+   */
+  TaskRemapper(const std::string& param);
+
+  /*
+   * Remaps, if necessary, the input task
+   */
+  std::string remap(const std::string& task) const;
+
+private:
+  // If present, match every incoming task to the target task
+  std::optional<std::string> _wildcard_match;
+  std::unordered_map<std::string, std::string> _task_remaps;
+};
+
+}
+
+#endif

--- a/nexus_common/include/nexus_common/task_remapper.hpp
+++ b/nexus_common/include/nexus_common/task_remapper.hpp
@@ -45,7 +45,9 @@ public:
    *    pick_and_place: [pick, place]
    *    a_and_b: [a, b]
    *
-   * Will remap "pick" or "place" to "pick_and_place", "a" and "b" to "a_and_b"
+   * Will remap "pick" or "place" to "pick_and_place", "a" and "b" to "a_and_b".
+   * Note: If the value is specified as an asterisk, "*", any value will be
+   *  remapped to the specified key.
    */
   TaskRemapper(const YAML::Node& remaps);
 

--- a/nexus_common/src/task_remapper.cpp
+++ b/nexus_common/src/task_remapper.cpp
@@ -43,7 +43,7 @@ TaskRemapper::TaskRemapper(const std::string& param)
   }
 }
 
-std::string TaskRemapper::remap(const std::string& task) const
+std::optional<std::string> TaskRemapper::remap(const std::string& task) const
 {
   if (this->_wildcard_match.has_value())
   {
@@ -54,7 +54,7 @@ std::string TaskRemapper::remap(const std::string& task) const
   {
     return it->second;
   }
-  return task;
+  return std::nullopt;
 }
 
 

--- a/nexus_common/src/task_remapper.cpp
+++ b/nexus_common/src/task_remapper.cpp
@@ -17,13 +17,10 @@
 
 #include "task_remapper.hpp"
 
-#include <yaml-cpp/yaml.h>
-
 namespace nexus::common {
 
-TaskRemapper::TaskRemapper(const std::string& param)
+TaskRemapper::TaskRemapper(const YAML::Node& remaps)
 {
-  const auto remaps = YAML::Load(param);
   for (const auto& n : remaps)
   {
     const auto task_type = n.first.as<std::string>();

--- a/nexus_common/src/task_remapper.cpp
+++ b/nexus_common/src/task_remapper.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Open Source Robotics Foundation
+ * Copyright (C) 2025 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nexus_common/src/task_remapper.cpp
+++ b/nexus_common/src/task_remapper.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2024 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "task_remapper.hpp"
+
+#include <yaml-cpp/yaml.h>
+
+namespace nexus::common {
+
+TaskRemapper::TaskRemapper(const std::string& param)
+{
+  const auto remaps = YAML::Load(param);
+  for (const auto& n : remaps)
+  {
+    const auto task_type = n.first.as<std::string>();
+    const auto& mappings = n.second;
+    for (const auto& m : mappings)
+    {
+      auto mapping = m.as<std::string>();
+      if (mapping == "*")
+      {
+        this->_wildcard_match = task_type;
+        this->_task_remaps.clear();
+        return;
+      }
+      // TODO(luca) check for duplicates, logging if found
+      this->_task_remaps.emplace(mapping, task_type);
+    }
+  }
+}
+
+std::string TaskRemapper::remap(const std::string& task) const
+{
+  if (this->_wildcard_match.has_value())
+  {
+    return this->_wildcard_match.value();
+  }
+  const auto it = this->_task_remaps.find(task);
+  if (it != this->_task_remaps.end())
+  {
+    return it->second;
+  }
+  return task;
+}
+
+
+}

--- a/nexus_common/src/task_remapper_test.cpp
+++ b/nexus_common/src/task_remapper_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Johnson & Johnson
+ * Copyright (C) 2024 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@
 #include <rmf_utils/catch.hpp>
 
 #include "task_remapper.hpp"
-#include "test_utils.hpp"
 
 namespace nexus::common::test {
 

--- a/nexus_common/src/task_remapper_test.cpp
+++ b/nexus_common/src/task_remapper_test.cpp
@@ -18,6 +18,8 @@
 #define CATCH_CONFIG_MAIN
 #include <rmf_utils/catch.hpp>
 
+#include <yaml-cpp/yaml.h>
+
 #include "task_remapper.hpp"
 
 namespace nexus::common::test {
@@ -27,7 +29,8 @@ TEST_CASE("task_remapping") {
     R"(
       pick_and_place: [pick, place]
     )";
-  auto remapper = TaskRemapper(param);
+  const auto yaml = YAML::Load(param);
+  const auto remapper = TaskRemapper(yaml);
   CHECK(remapper.remap("pick") == "pick_and_place");
   CHECK(remapper.remap("place") == "pick_and_place");
   CHECK(remapper.remap("other") == std::nullopt);
@@ -39,7 +42,8 @@ TEST_CASE("task_remapping_with_wildcard") {
       pick_and_place: [pick, place]
       main : ["*"]
     )";
-  auto remapper = TaskRemapper(param);
+  const auto yaml = YAML::Load(param);
+  const auto remapper = TaskRemapper(yaml);
   CHECK(remapper.remap("pick") == "main");
   CHECK(remapper.remap("place") == "main");
   CHECK(remapper.remap("other") == "main");
@@ -50,7 +54,8 @@ TEST_CASE("task_remapping_with_normal_and_wildcard") {
     R"(
       pick_and_place: [pick, "*"]
     )";
-  auto remapper = TaskRemapper(param);
+  const auto yaml = YAML::Load(param);
+  const auto remapper = TaskRemapper(yaml);
   CHECK(remapper.remap("pick") == "pick_and_place");
   CHECK(remapper.remap("place") == "pick_and_place");
 }

--- a/nexus_common/src/task_remapper_test.cpp
+++ b/nexus_common/src/task_remapper_test.cpp
@@ -30,7 +30,7 @@ TEST_CASE("task_remapping") {
   auto remapper = TaskRemapper(param);
   CHECK(remapper.remap("pick") == "pick_and_place");
   CHECK(remapper.remap("place") == "pick_and_place");
-  CHECK(remapper.remap("other") == "other");
+  CHECK(remapper.remap("other") == std::nullopt);
 }
 
 TEST_CASE("task_remapping_with_wildcard") {
@@ -43,6 +43,16 @@ TEST_CASE("task_remapping_with_wildcard") {
   CHECK(remapper.remap("pick") == "main");
   CHECK(remapper.remap("place") == "main");
   CHECK(remapper.remap("other") == "main");
+}
+
+TEST_CASE("task_remapping_with_normal_and_wildcard") {
+  std::string param =
+    R"(
+      pick_and_place: [pick, "*"]
+    )";
+  auto remapper = TaskRemapper(param);
+  CHECK(remapper.remap("pick") == "pick_and_place");
+  CHECK(remapper.remap("place") == "pick_and_place");
 }
 
 }

--- a/nexus_common/src/task_remapper_test.cpp
+++ b/nexus_common/src/task_remapper_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Open Source Robotics Foundation
+ * Copyright (C) 2025 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/nexus_common/src/task_remapper_test.cpp
+++ b/nexus_common/src/task_remapper_test.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2023 Johnson & Johnson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#define CATCH_CONFIG_MAIN
+#include <rmf_utils/catch.hpp>
+
+#include "task_remapper.hpp"
+#include "test_utils.hpp"
+
+namespace nexus::common::test {
+
+TEST_CASE("task_remapping") {
+  std::string param =
+    R"(
+      pick_and_place: [pick, place]
+    )";
+  auto remapper = TaskRemapper(param);
+  CHECK(remapper.remap("pick") == "pick_and_place");
+  CHECK(remapper.remap("place") == "pick_and_place");
+  CHECK(remapper.remap("other") == "other");
+}
+
+TEST_CASE("task_remapping_with_wildcard") {
+  std::string param =
+    R"(
+      pick_and_place: [pick, place]
+      main : ["*"]
+    )";
+  auto remapper = TaskRemapper(param);
+  CHECK(remapper.remap("pick") == "main");
+  CHECK(remapper.remap("place") == "main");
+  CHECK(remapper.remap("other") == "main");
+}
+
+}

--- a/nexus_system_orchestrator/src/context.hpp
+++ b/nexus_system_orchestrator/src/context.hpp
@@ -20,6 +20,7 @@
 
 #include "session.hpp"
 
+#include <nexus_common/task_remapper.hpp>
 #include <nexus_common/models/work_order.hpp>
 #include <nexus_endpoints.hpp>
 #include <nexus_orchestrator_msgs/msg/task_state.hpp>
@@ -43,8 +44,7 @@ public: rclcpp_lifecycle::LifecycleNode& node;
 public: std::string job_id;
 public: WorkOrder wo;
 public: std::vector<WorkcellTask> tasks;
-public: std::shared_ptr<const std::unordered_map<std::string,
-    std::string>> task_remaps;
+public: std::shared_ptr<const common::TaskRemapper> task_remapper;
   /**
    * Map of task ids and their assigned workcell ids.
    */

--- a/nexus_system_orchestrator/src/execute_task.cpp
+++ b/nexus_system_orchestrator/src/execute_task.cpp
@@ -42,15 +42,15 @@ BT::NodeStatus ExecuteTask::onStart()
   // Remap the BT filename to load if one is provided.
   std::string bt_name = task->type;
   const auto new_task = _ctx->task_remapper->remap(task->type);
-  if (new_task != task->type)
+  if (new_task.has_value())
   {
     RCLCPP_DEBUG(
       _ctx->node.get_logger(),
       "[ExecuteTask] Loading remapped BT [%s] for original task type [%s]",
-      new_task.c_str(),
+      new_task.value().c_str(),
       task->type.c_str()
     );
-    bt_name = new_task;
+    bt_name = new_task.value();
   }
   std::filesystem::path task_bt_path(this->_bt_path / (bt_name + ".xml"));
   if (!std::filesystem::is_regular_file(task_bt_path))

--- a/nexus_system_orchestrator/src/execute_task.cpp
+++ b/nexus_system_orchestrator/src/execute_task.cpp
@@ -41,16 +41,16 @@ BT::NodeStatus ExecuteTask::onStart()
 
   // Remap the BT filename to load if one is provided.
   std::string bt_name = task->type;
-  auto it = _ctx->task_remaps->find(task->type);
-  if (it != _ctx->task_remaps->end())
+  const auto new_task = _ctx->task_remapper->remap(task->type);
+  if (new_task != task->type)
   {
     RCLCPP_DEBUG(
       _ctx->node.get_logger(),
       "[ExecuteTask] Loading remapped BT [%s] for original task type [%s]",
-      it->second.c_str(),
+      new_task.c_str(),
       task->type.c_str()
     );
-    bt_name = it->second;
+    bt_name = new_task;
   }
   std::filesystem::path task_bt_path(this->_bt_path / (bt_name + ".xml"));
   if (!std::filesystem::is_regular_file(task_bt_path))

--- a/nexus_system_orchestrator/src/system_orchestrator.cpp
+++ b/nexus_system_orchestrator/src/system_orchestrator.cpp
@@ -104,8 +104,9 @@ SystemOrchestrator::SystemOrchestrator(const rclcpp::NodeOptions& options)
     desc.read_only = true;
     desc.description =
       "A yaml containing a dictionary of task types and an array of remaps.";
-    const auto param = this->declare_parameter("remap_task_types", "", desc);
-    this->_task_remapper = std::make_shared<common::TaskRemapper>(param);
+    const auto yaml = this->declare_parameter("remap_task_types", "", desc);
+    const auto remaps = YAML::Load(yaml);
+    this->_task_remapper = std::make_shared<common::TaskRemapper>(remaps);
   }
 
   {

--- a/nexus_system_orchestrator/src/system_orchestrator.cpp
+++ b/nexus_system_orchestrator/src/system_orchestrator.cpp
@@ -100,23 +100,12 @@ SystemOrchestrator::SystemOrchestrator(const rclcpp::NodeOptions& options)
   }
 
   {
-    _task_remaps =
-      std::make_shared<std::unordered_map<std::string, std::string>>();
     ParameterDescriptor desc;
     desc.read_only = true;
     desc.description =
       "A yaml containing a dictionary of task types and an array of remaps.";
-    const auto yaml = this->declare_parameter("remap_task_types", "", desc);
-    const auto remaps = YAML::Load(yaml);
-    for (const auto& n : remaps)
-    {
-      const auto task_type = n.first.as<std::string>();
-      const auto& mappings = n.second;
-      for (const auto& m : mappings)
-      {
-        this->_task_remaps->emplace(m.as<std::string>(), task_type);
-      }
-    }
+    const auto param = this->declare_parameter("remap_task_types", "", desc);
+    this->_task_remapper = std::make_shared<common::TaskRemapper>(param);
   }
 
   {
@@ -545,7 +534,7 @@ void SystemOrchestrator::_create_job(const WorkOrderActionType::Goal& goal)
 
   // using `new` because make_shared does not work with aggregate initializer
   std::shared_ptr<Context> ctx{new Context{*this,
-      goal.order.id, wo, tasks, this->_task_remaps,
+      goal.order.id, wo, tasks, this->_task_remapper,
       std::unordered_map<std::string, std::string>{},
       this->_workcell_sessions,
       this->_transporter_sessions, {}, nullptr,

--- a/nexus_system_orchestrator/src/system_orchestrator.hpp
+++ b/nexus_system_orchestrator/src/system_orchestrator.hpp
@@ -24,6 +24,7 @@
 #include <nexus_common/action_client_bt_node.hpp>
 #include <nexus_common/models/work_order.hpp>
 #include <nexus_common/sync_service_client.hpp>
+#include <nexus_common/task_remapper.hpp>
 #include <nexus_endpoints.hpp>
 #include <nexus_lifecycle_manager/lifecycle_manager.hpp>
 #include <nexus_orchestrator_msgs/msg/workcell_task.hpp>
@@ -96,8 +97,8 @@ private:
   std::unique_ptr<lifecycle_manager::LifecycleManager<>> _lifecycle_mgr{nullptr};
   rclcpp::TimerBase::SharedPtr _pre_configure_timer;
   rclcpp::SubscriptionBase::SharedPtr _estop_sub;
-  // mapping of mapped task type and the original
-  std::shared_ptr<std::unordered_map<std::string, std::string>> _task_remaps;
+  // Manages task remapping
+  std::shared_ptr<common::TaskRemapper> _task_remapper;
   std::shared_ptr<OnSetParametersCallbackHandle> _param_cb_handle;
 
   /**

--- a/nexus_workcell_orchestrator/src/task_parser.cpp
+++ b/nexus_workcell_orchestrator/src/task_parser.cpp
@@ -29,29 +29,10 @@ Task TaskParser::parse_task(
 {
   return Task{
     workcell_task.id,
-    this->remap_task_type(workcell_task.type),
+    workcell_task.type,
     YAML::Load(workcell_task.payload),
     YAML::Load(workcell_task.previous_results),
   };
-}
-
-//==============================================================================
-void TaskParser::add_remap_task_type(const std::string& remap_from_type,
-  const std::string& remap_to_type)
-{
-  this->_remap_task_types[remap_from_type] = remap_to_type;
-}
-
-//==============================================================================
-std::string TaskParser::remap_task_type(const std::string& task_type)
-{
-  auto remap_it = this->_remap_task_types.find(task_type);
-
-  if (remap_it != this->_remap_task_types.end())
-  {
-    return remap_it->second;
-  }
-  return task_type;
 }
 
 } // namespace nexus::workcell_orchestrator

--- a/nexus_workcell_orchestrator/src/task_parser.hpp
+++ b/nexus_workcell_orchestrator/src/task_parser.hpp
@@ -39,17 +39,9 @@ public: TaskParser() {}
 public: Task parse_task(const nexus_orchestrator_msgs::msg::WorkcellTask& task);
 
   /**
-   * Add task type to remap to.
-   */
-public: void add_remap_task_type(const std::string& remap_from_type,
-    const std::string& remap_to_type);
-
-  /**
    * Remaps task types if a remap entry is found for the given type.
    */
 public: std::string remap_task_type(const std::string& task_type);
-
-private: std::unordered_map<std::string, std::string> _remap_task_types;
 };
 
 } // namespace nexus::workcell_orchestrator

--- a/nexus_workcell_orchestrator/src/workcell_orchestrator.cpp
+++ b/nexus_workcell_orchestrator/src/workcell_orchestrator.cpp
@@ -93,7 +93,6 @@ WorkcellOrchestrator::WorkcellOrchestrator(const rclcpp::NodeOptions& options)
     desc.description =
       "A yaml containing a dictionary of task types and an array of remaps.";
     const auto param = this->declare_parameter("remap_task_types", "", desc);
-    this->_task_remapper = std::make_shared<common::TaskRemapper>(param);
   }
   {
     ParameterDescriptor desc;
@@ -685,14 +684,7 @@ auto WorkcellOrchestrator::_configure(
   try
   {
     YAML::Node node = YAML::Load(remap_caps);
-    for (YAML::const_iterator it = node.begin(); it != node.end(); ++it)
-    {
-      for (std::size_t i = 0; i < it->second.size(); ++i)
-      {
-        this->_task_parser.add_remap_task_type(
-          it->second[i].as<std::string>(), it->first.as<std::string>());
-      }
-    }
+    this->_task_remapper = std::make_shared<common::TaskRemapper>(node);
   }
   catch (YAML::ParserException& e)
   {

--- a/nexus_workcell_orchestrator/src/workcell_orchestrator.cpp
+++ b/nexus_workcell_orchestrator/src/workcell_orchestrator.cpp
@@ -979,17 +979,19 @@ BT::Tree WorkcellOrchestrator::_create_bt(const std::shared_ptr<Context>& ctx)
   // To keep things simple, the task type is used as the key for the behavior tree to use.
   this->_ctx_mgr->set_active_context(ctx);
   const auto new_task = this->_task_remapper->remap(ctx->task.type);
-  if (new_task != ctx->task.type)
+  auto bt_name = ctx->task.type;
+  if (new_task.has_value())
   {
     RCLCPP_DEBUG(
       this->get_logger(),
       "Loading remapped BT [%s] for original task type [%s]",
-      new_task.c_str(),
+      new_task.value().c_str(),
       ctx->task.type.c_str()
     );
+    bt_name = new_task.value();
   }
   return this->_bt_factory->createTreeFromFile(this->_bt_store.get_bt(
-        new_task));
+        bt_name));
 }
 
 void WorkcellOrchestrator::_handle_command_success(

--- a/nexus_workcell_orchestrator/src/workcell_orchestrator.hpp
+++ b/nexus_workcell_orchestrator/src/workcell_orchestrator.hpp
@@ -28,6 +28,7 @@
 
 #include <nexus_common/action_client_bt_node.hpp>
 #include <nexus_common/bt_store.hpp>
+#include <nexus_common/task_remapper.hpp>
 
 #include <behaviortree_cpp_v3/action_node.h>
 #include <behaviortree_cpp_v3/bt_factory.h>
@@ -124,8 +125,8 @@ private: std::list<std::shared_ptr<Context>> _ctxs;
 private: std::shared_ptr<ContextManager> _ctx_mgr;
 private: std::unique_ptr<lifecycle_manager::LifecycleManager<>> _lifecycle_mgr{
     nullptr};
-// mapping of mapped task type and the original
-private: std::unordered_map<std::string, std::string> _task_remaps;
+// Takes care of remapping tasks
+private: std::shared_ptr<common::TaskRemapper> _task_remapper;
 private: TaskParser _task_parser;
 private: pluginlib::ClassLoader<TaskChecker> _task_checker_loader;
 private: std::shared_ptr<TaskChecker> _task_checker;


### PR DESCRIPTION
This PR refactors the task remapping capability in `nexus_system_orchestrator` (which was fully fledged) and the one in `nexus_workcell_orchestrator` (that was actually unimplemented) into a common `TaskRemapper` class.

This class has basic wildcard support, if it finds such a remapping:

```
    pick_and_place: ["*"],
```

It will override every other defined remap and just remap every single task to the requested `pick_and_place`.
I added a set of unit tests to show how the functionality works and now both system and workcell orchestrator share the same codebase for task remapping.

In the future we can consider more complex behaviors (i.e. proper wildcard support)