### PR TITLE
Migrate to RMW Zenoh

### DIFF
--- a/.github/workflows/nexus_integration_tests.yaml
+++ b/.github/workflows/nexus_integration_tests.yaml
@@ -38,6 +38,6 @@ jobs:
     - name: build
       run: /ros_entrypoint.sh colcon build --packages-up-to nexus_calibration nexus_gazebo nexus_demos nexus_motion_planner --mixin release lld --cmake-args -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
     - name: Test - Unit Tests
-      run: . ./install/setup.bash && RMW_IMPLEMENTATION=rmw_cyclonedds_cpp /ros_entrypoint.sh colcon test --packages-select nexus_motion_planner --event-handlers=console_direct+
+      run: . ./install/setup.bash && RMW_IMPLEMENTATION=rmw_zenoh_cpp /ros_entrypoint.sh colcon test --packages-select nexus_motion_planner --event-handlers=console_direct+
     - name: Test - Integration Test
-      run: . ./install/setup.bash && cd nexus_demos && RMW_IMPLEMENTATION=rmw_cyclonedds_cpp /ros_entrypoint.sh python3 -m unittest
+      run: . ./install/setup.bash && cd nexus_demos && RMW_IMPLEMENTATION=rmw_zenoh_cpp /ros_entrypoint.sh python3 -m unittest

--- a/.github/workflows/nexus_integration_tests.yaml
+++ b/.github/workflows/nexus_integration_tests.yaml
@@ -27,6 +27,9 @@ jobs:
     - name: vcs
       run: |
         vcs import . < abb.repos
+    - name: rmw_zenoh_cpp source
+      run: |
+        git clone https://github.com/ros2/rmw_zenoh -b jazzy
     - name: rosdep
       run: |
         apt update

--- a/nexus_demos/README.md
+++ b/nexus_demos/README.md
@@ -18,17 +18,17 @@ ros2 launch nexus_demos launch.py headless:=False
 ### Method 2: Launch System Orchestrator and 1 Workcell without Zenoh bridge (Same ROS_DOMAIN_ID)
 Launch with Workcell 1
 ```bash
-ros2 launch nexus_demos launch.py headless:=False use_zenoh_bridge:=False run_workcell_1:=true run_workcell_2:=false
+ros2 launch nexus_demos launch.py headless:=False run_workcell_1:=true run_workcell_2:=false
 ```
 
 Launch with Workcell 2
 ```bash
-ros2 launch nexus_demos launch.py headless:=False use_zenoh_bridge:=False run_workcell_1:=false run_workcell_2:=true
+ros2 launch nexus_demos launch.py headless:=False run_workcell_1:=false run_workcell_2:=true
 ```
 
 Testing with real hardware
 ```bash
-ros2 launch nexus_demos launch.py headless:=False use_zenoh_bridge:=False run_workcell_1:=True run_workcell_2:=False use_fake_hardware:=False robot1_ip:=<IP_ADDR>
+ros2 launch nexus_demos launch.py headless:=False run_workcell_1:=True run_workcell_2:=False use_fake_hardware:=False robot1_ip:=<IP_ADDR>
 ```
 
 ## Launch Orchestrators individually

--- a/nexus_demos/README.md
+++ b/nexus_demos/README.md
@@ -8,8 +8,8 @@ The [launch.py script](launch/launch.py) will launch the system orchestrator and
 >NOTE: The ROS_DOMAIN_ID occupied by the Zenoh bridges during launch time may be different from the `domain` values in the Zenoh bridge configurations. This is because the launch file overrides the domain ID of the zenoh bridges to ensure that it is same as that of the orchestrator.
 
 ### Method 1: Launch system orchestrator, IRB1300 workcell and IRB910SC Workcell together with Zenoh bridge
-> NOTE: Before running any of these commands, you must set the rmw implmentation to cyclonedds with
-`export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp`
+> NOTE: Before running any of these commands, you must set the rmw implmentation to Zenoh with
+`export RMW_IMPLEMENTATION=rmw_zenoh_cpp`
 (If testing with real hardware, specify the arguments `use_fake_hardware=False`, `robot1_ip=<IP>` and `robot2_ip=<IP>`)
 ```bash
 ros2 launch nexus_demos launch.py headless:=False

--- a/nexus_demos/config/zenoh/system_orchestrator_router_config.json5
+++ b/nexus_demos/config/zenoh/system_orchestrator_router_config.json5
@@ -1,0 +1,11 @@
+{
+  mode: "router",
+  connect: {
+    endpoints: [],
+  },
+  listen: {
+    endpoints: [
+      "tcp/[::]:7447"
+    ],
+  },
+}

--- a/nexus_demos/config/zenoh/system_orchestrator_session_config.json5
+++ b/nexus_demos/config/zenoh/system_orchestrator_session_config.json5
@@ -1,0 +1,25 @@
+{
+  mode: "peer",
+  connect: {
+    endpoints: {
+      router: [
+      // system orchestrator
+        "tcp/localhost:7447"
+      ]
+    },
+  },
+
+  /// Configuration of data messages timestamps management.
+  timestamping: {
+    /// Whether data messages should be timestamped if not already.
+    /// Accepts a single boolean value or different values for router, peer and client.
+    ///
+    /// ROS setting: PublicationCache which is required for transient_local durability
+    ///              only works when time-stamping is enabled.
+    enabled: { router: true, peer: true, client: true },
+    /// Whether data messages with timestamps in the future should be dropped or not.
+    /// If set to false (default), messages with timestamps in the future are retimestamped.
+    /// Timestamps are ignored if timestamping is disabled.
+    drop_future_timestamp: false,
+  },
+}

--- a/nexus_demos/config/zenoh/workcell_1_router_config.json5
+++ b/nexus_demos/config/zenoh/workcell_1_router_config.json5
@@ -1,0 +1,99 @@
+{
+  mode: "router",
+  connect: {
+    endpoints: [
+      // system orchestrator
+      "tcp/localhost:7447",
+    ],
+  },
+  listen: {
+    endpoints: [
+      "tcp/[::]:7448"
+    ],
+  },
+  access_control: {
+    "enabled": true,
+    "default_permission": "deny",
+    "rules":
+    [
+      {
+        "id": "liveliness_tokens",
+        "messages": [
+          "liveliness_token",
+          "liveliness_query",
+          "declare_liveliness_subscriber",
+        ],
+        "flows": ["ingress", "egress"],
+        "permission": "allow",
+        "key_exprs": [
+          "@ros2_lv/**"
+        ],
+      },
+      {
+        "id": "bridged_topics",
+        "messages": [
+          "put",
+          "declare_subscriber",
+        ],
+        "flows": ["ingress", "egress"],
+        "permission": "allow",
+        "key_exprs": [
+          "*/workcell_1/workcell_state/**",
+        ],
+      },
+      {
+        "id": "bridged_services",
+        "messages": [
+          "query",
+          "declare_queryable",
+          "reply",
+        ],
+        "flows": ["ingress", "egress"],
+        "permission": "allow",
+        "key_exprs": [
+          "*/register_workcell/**",
+          "*/workcell_1/is_task_doable/**",
+          "*/workcell_1/queue_task/**",
+          "*/workcell_1/remove_pending_task/**",
+          "*/workcell_1/get_state/**",
+          "*/workcell_1/change_state/**",
+          "*/workcell_1/signal/**",
+          "*/workcell_1/pause/**",
+        ],
+      },
+      {
+        "id": "bridged_actions",
+        "messages": [
+          "query",
+          "declare_queryable",
+          "reply",
+          "put",
+          "declare_subscriber",
+        ],
+        "flows": ["ingress", "egress"],
+        "permission": "allow",
+        "key_exprs": [
+          "*/workcell_1/request/**",
+        ],
+      },
+    ],
+    "subjects":
+    [
+      {
+        "id": "all_subjects",
+      },
+    ],
+    "policies":
+    [
+      {
+        "rules": [
+          "bridged_topics",
+          "bridged_services",
+          "bridged_actions",
+          "liveliness_tokens",
+        ],
+        "subjects": ["all_subjects"],
+      },
+    ]
+  },
+}

--- a/nexus_demos/config/zenoh/workcell_1_session_config.json5
+++ b/nexus_demos/config/zenoh/workcell_1_session_config.json5
@@ -1,0 +1,23 @@
+{
+  mode: "peer",
+  connect: {
+    endpoints: [
+      // workcell orchestrator
+      "tcp/localhost:7448",
+    ],
+  },
+
+  /// Configuration of data messages timestamps management.
+  timestamping: {
+    /// Whether data messages should be timestamped if not already.
+    /// Accepts a single boolean value or different values for router, peer and client.
+    ///
+    /// ROS setting: PublicationCache which is required for transient_local durability
+    ///              only works when time-stamping is enabled.
+    enabled: { router: true, peer: true, client: true },
+    /// Whether data messages with timestamps in the future should be dropped or not.
+    /// If set to false (default), messages with timestamps in the future are retimestamped.
+    /// Timestamps are ignored if timestamping is disabled.
+    drop_future_timestamp: false,
+  },
+}

--- a/nexus_demos/config/zenoh/workcell_2_router_config.json5
+++ b/nexus_demos/config/zenoh/workcell_2_router_config.json5
@@ -1,0 +1,99 @@
+{
+  mode: "router",
+  connect: {
+    endpoints: [
+      // system orchestrator
+      "tcp/localhost:7447",
+    ],
+  },
+  listen: {
+    endpoints: [
+      "tcp/[::]:7449"
+    ],
+  },
+  access_control: {
+    "enabled": true,
+    "default_permission": "deny",
+    "rules":
+    [
+      {
+        "id": "liveliness_tokens",
+        "messages": [
+          "liveliness_token",
+          "liveliness_query",
+          "declare_liveliness_subscriber",
+        ],
+        "flows": ["ingress", "egress"],
+        "permission": "allow",
+        "key_exprs": [
+          "@ros2_lv/**"
+        ],
+      },
+      {
+        "id": "bridged_topics",
+        "messages": [
+          "put",
+          "declare_subscriber",
+        ],
+        "flows": ["ingress", "egress"],
+        "permission": "allow",
+        "key_exprs": [
+          "*/workcell_2/workcell_state/**",
+        ],
+      },
+      {
+        "id": "bridged_services",
+        "messages": [
+          "query",
+          "declare_queryable",
+          "reply",
+        ],
+        "flows": ["ingress", "egress"],
+        "permission": "allow",
+        "key_exprs": [
+          "*/register_workcell/**",
+          "*/workcell_2/is_task_doable/**",
+          "*/workcell_2/queue_task/**",
+          "*/workcell_2/remove_pending_task/**",
+          "*/workcell_2/get_state/**",
+          "*/workcell_2/change_state/**",
+          "*/workcell_2/signal/**",
+          "*/workcell_2/pause/**",
+        ],
+      },
+      {
+        "id": "bridged_actions",
+        "messages": [
+          "query",
+          "declare_queryable",
+          "reply",
+          "put",
+          "declare_subscriber",
+        ],
+        "flows": ["ingress", "egress"],
+        "permission": "allow",
+        "key_exprs": [
+          "*/workcell_2/request/**",
+        ],
+      },
+    ],
+    "subjects":
+    [
+      {
+        "id": "all_subjects",
+      },
+    ],
+    "policies":
+    [
+      {
+        "rules": [
+          "bridged_topics",
+          "bridged_services",
+          "bridged_actions",
+          "liveliness_tokens",
+        ],
+        "subjects": ["all_subjects"],
+      },
+    ]
+  },
+}

--- a/nexus_demos/config/zenoh/workcell_2_session_config.json5
+++ b/nexus_demos/config/zenoh/workcell_2_session_config.json5
@@ -1,0 +1,23 @@
+{
+  mode: "peer",
+  connect: {
+    endpoints: [
+      // workcell orchestrator
+      "tcp/localhost:7449",
+    ],
+  },
+
+  /// Configuration of data messages timestamps management.
+  timestamping: {
+    /// Whether data messages should be timestamped if not already.
+    /// Accepts a single boolean value or different values for router, peer and client.
+    ///
+    /// ROS setting: PublicationCache which is required for transient_local durability
+    ///              only works when time-stamping is enabled.
+    enabled: { router: true, peer: true, client: true },
+    /// Whether data messages with timestamps in the future should be dropped or not.
+    /// If set to false (default), messages with timestamps in the future are retimestamped.
+    /// Timestamps are ignored if timestamping is disabled.
+    drop_future_timestamp: false,
+  },
+}

--- a/nexus_demos/launch/inter_workcell.launch.py
+++ b/nexus_demos/launch/inter_workcell.launch.py
@@ -106,6 +106,7 @@ def activate_node(target_node: LifecycleNode, depend_node: LifecycleNode = None)
 
 
 def launch_setup(context, *args, **kwargs):
+    ros_domain_id = LaunchConfiguration("ros_domain_id")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
     use_rmf_transporter = LaunchConfiguration("use_rmf_transporter")
     zenoh_config_package = LaunchConfiguration("zenoh_config_package")
@@ -208,6 +209,7 @@ def launch_setup(context, *args, **kwargs):
                 launch_arguments={
                     "zenoh_config_package": zenoh_config_package,
                     "zenoh_router_config_filename": zenoh_router_config_filename,
+                    "ros_domain_id": ros_domain_id.perform(context),
                 }.items(),
             )
         ]
@@ -221,6 +223,8 @@ def launch_setup(context, *args, **kwargs):
     )
 
     return [
+        zenoh_router,
+        SetEnvironmentVariable("ROS_DOMAIN_ID", ros_domain_id),
         SetEnvironmentVariable(
             "ZENOH_SESSION_CONFIG_URI",
             PathJoinSubstitution(
@@ -235,7 +239,6 @@ def launch_setup(context, *args, **kwargs):
         transporter_node,
         mock_emergency_alarm_node,
         nexus_panel,
-        zenoh_router,
         activate_system_orchestrator,
         activate_transporter_node,
         activate_node(mock_emergency_alarm_node),
@@ -246,6 +249,11 @@ def generate_launch_description():
 
     return launch.LaunchDescription(
         [
+            DeclareLaunchArgument(
+                "ros_domain_id",
+                default_value="0",
+                description="ROS_DOMAIN_ID environment variable",
+            ),
             DeclareLaunchArgument(
                 "use_fake_hardware",
                 default_value="true",

--- a/nexus_demos/launch/launch.py
+++ b/nexus_demos/launch/launch.py
@@ -49,7 +49,27 @@ def launch_setup(context, *args, **kwargs):
     run_workcell_1 = LaunchConfiguration("run_workcell_1")
     run_workcell_2 = LaunchConfiguration("run_workcell_2")
 
+    inter_workcell_domain_id = 0
+    workcell_1_domain_id = 0
+    workcell_2_domain_id = 0
     log_msg = ""
+
+    if "ROS_DOMAIN_ID" in os.environ:
+        inter_workcell_domain_id = int(os.environ["ROS_DOMAIN_ID"])
+        if not 0 < inter_workcell_domain_id < 230:
+            log_msg += (
+                "ROS_DOMAIN_ID not within the range of 0 to 230, setting it to 0. \n"
+            )
+            inter_workcell_domain_id = 0
+
+    workcell_1_domain_id = inter_workcell_domain_id + 1
+    workcell_2_domain_id = inter_workcell_domain_id + 2
+
+    log_msg += f"Inter-workcell has ROS_DOMAIN_ID {inter_workcell_domain_id}\n"
+    if run_workcell_1.perform(context).lower() == "true":
+        log_msg += f"Workcell 1 has ROS_DOMAIN_ID {workcell_1_domain_id}\n"
+    if run_workcell_2.perform(context).lower() == "true":
+        log_msg += f"Workcell 2 has ROS_DOMAIN_ID {workcell_2_domain_id}\n"
 
     main_bt_filename = "main.xml"
     remap_task_types = """{
@@ -80,6 +100,7 @@ def launch_setup(context, *args, **kwargs):
                     )
                 ],
                 launch_arguments={
+                    "ros_domain_id": str(inter_workcell_domain_id),
                     "zenoh_config_package": "nexus_demos",
                     "zenoh_router_config_filename": "config/zenoh/system_orchestrator_router_config.json5",
                     "zenoh_session_config_filename": "config/zenoh/system_orchestrator_session_config.json5",
@@ -114,6 +135,7 @@ def launch_setup(context, *args, **kwargs):
                         "/config/workcell_1_bts",
                     ),
                     "task_checker_plugin": "nexus::task_checkers::FilepathChecker",
+                    "ros_domain_id": str(workcell_1_domain_id),
                     "headless": headless,
                     "controller_config_package": "nexus_demos",
                     "planner_config_package": "nexus_demos",
@@ -156,6 +178,7 @@ def launch_setup(context, *args, **kwargs):
                         "/config/workcell_2_bts",
                     ),
                     "task_checker_plugin": "nexus::task_checkers::FilepathChecker",
+                    "ros_domain_id": str(workcell_2_domain_id),
                     "headless": headless,
                     "controller_config_package": "nexus_demos",
                     "planner_config_package": "nexus_demos",

--- a/nexus_demos/launch/launch.py
+++ b/nexus_demos/launch/launch.py
@@ -33,10 +33,10 @@ from launch_ros.substitutions import FindPackageShare
 def launch_setup(context, *args, **kwargs):
     if (
         "RMW_IMPLEMENTATION" not in os.environ
-        or os.environ["RMW_IMPLEMENTATION"] != "rmw_cyclonedds_cpp"
+        or os.environ["RMW_IMPLEMENTATION"] != "rmw_zenoh_cpp"
     ):
         print(
-            "Only cycloneDDS is supported, the environment variable RMW_IMPLEMENTATION must be set to rmw_cyclonedds_cpp",
+            "Only RMW Zenoh is supported, the environment variable RMW_IMPLEMENTATION must be set to rmw_zenoh_cpp",
             file=sys.stderr,
         )
         exit(1)

--- a/nexus_demos/launch/zenoh_router.launch.py
+++ b/nexus_demos/launch/zenoh_router.launch.py
@@ -41,7 +41,7 @@ def launch_setup(context, *args, **kwargs):
         )
     ]
 
-    zenoh_bridge_exec = ExecuteProcess(
+    zenoh_router_exec = ExecuteProcess(
         cmd=cmd,
         shell=True,
         additional_env={
@@ -54,7 +54,7 @@ def launch_setup(context, *args, **kwargs):
         },
     )
 
-    return [zenoh_bridge_exec]
+    return [zenoh_router_exec]
 
 def generate_launch_description():
     declared_arguments = []

--- a/nexus_demos/launch/zenoh_router.launch.py
+++ b/nexus_demos/launch/zenoh_router.launch.py
@@ -1,0 +1,96 @@
+# Copyright 2025 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from launch import LaunchDescription
+from launch.actions import (
+    DeclareLaunchArgument,
+    ExecuteProcess,
+    OpaqueFunction,
+)
+from launch.substitutions import (
+    LaunchConfiguration,
+    PathJoinSubstitution,
+)
+from launch_ros.substitutions import (
+    ExecutableInPackage,
+    FindPackageShare,
+)
+
+
+def launch_setup(context, *args, **kwargs):
+    ros_domain_id = LaunchConfiguration("ros_domain_id")
+    log_level = LaunchConfiguration("log_level")
+    zenoh_config_package = LaunchConfiguration("zenoh_config_package")
+    zenoh_router_config_filename = LaunchConfiguration("zenoh_router_config_filename")
+
+    cmd = [
+        ExecutableInPackage(
+            executable="rmw_zenohd",
+            package="rmw_zenoh_cpp",
+        )
+    ]
+
+    zenoh_bridge_exec = ExecuteProcess(
+        cmd=cmd,
+        shell=True,
+        additional_env={
+            "ROS_DOMAIN_ID": ros_domain_id.perform(context),
+            "ZENOH_ROUTER_CONFIG_URI": PathJoinSubstitution([
+                FindPackageShare(zenoh_config_package),
+                zenoh_router_config_filename
+            ]),
+            "RUST_LOG": log_level.perform(context)
+        },
+    )
+
+    return [zenoh_bridge_exec]
+
+def generate_launch_description():
+    declared_arguments = []
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            name="ros_domain_id",
+            default_value="0",
+            description="ROS_DOMAIN_ID environment variable",
+        )
+    )
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            name="log_level",
+            default_value="zenoh=debug",
+            description="Log level of zenoh DDS Bridge",
+        )
+    )
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            name="zenoh_config_package",
+            default_value="nexus_demos",
+            description="Package containing RWM Zenoh configurations",
+        )
+    )
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            name="zenoh_router_config_filename",
+            default_value="config/zenoh/system_orchestrator_router_config.json5",
+            description="RMW Zenoh configuration filepath",
+        )
+    )
+
+    return LaunchDescription(
+        declared_arguments + [OpaqueFunction(function=launch_setup)]
+    )

--- a/nexus_demos/package.xml
+++ b/nexus_demos/package.xml
@@ -26,7 +26,7 @@
   <depend>tf2_ros</depend>
   <depend>yaml-cpp</depend>
   <depend>yaml_cpp_vendor</depend>
-  <depend>rmw_cyclonedds_cpp</depend>
+  <depend>rmw_zenoh_cpp</depend>
 
   <exec_depend>abb_bringup</exec_depend>
   <exec_depend>abb_irb1300_support</exec_depend>
@@ -43,7 +43,6 @@
   <exec_depend>nexus_rviz_plugins</exec_depend>
   <exec_depend>nexus_system_orchestrator</exec_depend>
   <exec_depend>nexus_workcell_orchestrator</exec_depend>
-  <exec_depend>nexus_zenoh_bridge_dds_vendor</exec_depend>
 
   <!-- Open-RMF dependencies. -->
   <exec_depend>rmf_building_map_tools</exec_depend>

--- a/nexus_network_configuration/README.md
+++ b/nexus_network_configuration/README.md
@@ -6,7 +6,7 @@ This package simplifies the Zenoh DDS Bridge setup for multiple NEXUS orchestrat
 
 # First-time setup for deploying a LOCALHOST only environment
 
-1. Make sure that CycloneDDS is installed and made the default middleware, and that multicast on loopback interface is enabled for localhost-only communication.
+1. Make sure that `rmw_zenoh_cpp` is installed and made the default middleware, and that multicast on loopback interface is enabled for localhost-only communication.
 ```
 ./scripts/set_up_network.sh
 ```

--- a/nexus_network_configuration/scripts/set_up_network.sh
+++ b/nexus_network_configuration/scripts/set_up_network.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 # This script does the following:
-# 1. Install CycloneDDS (Iron dist.) if not already installed
-# 2. Change RMW_IMPLEMENTATION to CycloneDDS
+# 1. Install RMW Zenoh (Jazzy dist.) if not already installed
+# 2. Change RMW_IMPLEMENTATION to rmw_zenoh_cpp
 # 3. Enable multicast on loopback interface
 
-RMW_PACKAGE="ros-jazzy-rmw-cyclonedds-cpp"
+RMW_PACKAGE="ros-jazzy-rmw-zenoh-cpp"
 
 PKG_OK=$(dpkg-query -W --showformat='${Status}\n' $RMW_PACKAGE|grep "install ok installed")
 
@@ -23,12 +23,12 @@ if [ "$PKG_OK" = "" ]; then
 fi
 
 while true; do
-    read -p "Restart ROS Daemon and set RMW_IMPLEMENTATION to 'rmw_cyclonedds_cpp'? (y/n)" yn
+    read -p "Restart ROS Daemon and set RMW_IMPLEMENTATION to 'rmw_zenoh_cpp'? (y/n)" yn
     case $yn in
         [Yy]* )
           ros2 daemon stop;
           echo "Stopped ROS2 Daemon"
-          export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp;
+          export RMW_IMPLEMENTATION=rmw_zenoh_cpp;
           ros2 daemon start;
           echo "Started ROS2 Daemon"
           break;;


### PR DESCRIPTION
* Use `rmw_zenoh_cpp` instead of vendored zenoh bridge
* source build of `rmw_zenoh_cpp` required

TODO:
* resolve domain ID separated actions (for workcell requests) and services (for workcell registration), between the system orchestrator and different workcell orchestrators