### PR TITLE
Autostarting lifecycle nodes (fixes #77)

### DIFF
--- a/nexus_calibration/test/nexus_calibration.launch.py
+++ b/nexus_calibration/test/nexus_calibration.launch.py
@@ -18,84 +18,11 @@ from ament_index_python.packages import get_package_share_directory
 
 import launch_ros
 from launch_ros.actions import LifecycleNode
-from launch_ros.event_handlers import OnStateTransition
 import launch
 from launch.actions import (
-    GroupAction,
     OpaqueFunction,
     ExecuteProcess,
 )
-import lifecycle_msgs
-
-def activate_node(target_node: LifecycleNode, depend_node: LifecycleNode = None):
-
-    configure_event = None
-
-    if depend_node is not None:
-        configure_event = launch.actions.RegisterEventHandler(
-            OnStateTransition(
-                target_lifecycle_node=depend_node,
-                goal_state="active",
-                entities=[
-                    launch.actions.EmitEvent(
-                        event=launch_ros.events.lifecycle.ChangeState(
-                            lifecycle_node_matcher=launch.events.matches_action(
-                                target_node
-                            ),
-                            transition_id=lifecycle_msgs.msg.Transition.TRANSITION_CONFIGURE,
-                        )
-                    )
-                ],
-            )
-        )
-    else:
-        # Make the talker node take the 'configure' transition.
-        configure_event = launch.actions.EmitEvent(
-            event=launch_ros.events.lifecycle.ChangeState(
-                lifecycle_node_matcher=launch.events.matches_action(target_node),
-                transition_id=lifecycle_msgs.msg.Transition.TRANSITION_CONFIGURE,
-            )
-        )
-
-    inactive_state_handler = launch.actions.RegisterEventHandler(
-        OnStateTransition(
-            target_lifecycle_node=target_node,
-            goal_state="inactive",
-            entities=[
-                launch.actions.LogInfo(
-                    msg=f"node {target_node.node_executable} reached the 'inactive' state."
-                ),
-                launch.actions.EmitEvent(
-                    event=launch_ros.events.lifecycle.ChangeState(
-                        lifecycle_node_matcher=launch.events.matches_action(
-                            target_node
-                        ),
-                        transition_id=lifecycle_msgs.msg.Transition.TRANSITION_ACTIVATE,
-                    )
-                ),
-            ],
-        )
-    )
-
-    active_state_handler = launch.actions.RegisterEventHandler(
-        OnStateTransition(
-            target_lifecycle_node=target_node,
-            goal_state="active",
-            entities=[
-                launch.actions.LogInfo(
-                    msg=f"node {target_node.node_executable} reached the 'active' state"
-                ),
-            ],
-        )
-    )
-
-    return GroupAction(
-        [
-            configure_event,
-            inactive_state_handler,
-            active_state_handler,
-        ]
-    )
 
 def launch_setup(context, *args, **kwargs):
     curdir = pathlib.Path(__file__).parent.resolve()
@@ -117,13 +44,13 @@ def launch_setup(context, *args, **kwargs):
             package="nexus_calibration",
             executable="nexus_calibration_node",
             name="nexus_calibration_node",
-            parameters=[config_path]
+            parameters=[config_path],
+            autostart=True
         )
 
     return [
         simulation,
-        calibration_node,
-        activate_node(calibration_node)
+        calibration_node
     ]
 
 def generate_launch_description():

--- a/nexus_motion_planner/launch/demo_planner_server.launch.py
+++ b/nexus_motion_planner/launch/demo_planner_server.launch.py
@@ -27,7 +27,7 @@ from launch.substitutions import (
     PathJoinSubstitution,
 )
 
-from launch_ros.actions import Node
+from launch_ros.actions import Node, LifecycleNode
 from launch_ros.descriptions import ParameterValue
 from launch_ros.substitutions import FindPackageShare
 
@@ -50,6 +50,7 @@ def launch_setup(context, *args, **kwargs):
     robot_xacro_file = LaunchConfiguration("robot_xacro_file")
     moveit_config_package = LaunchConfiguration("moveit_config_package")
     moveit_config_file = LaunchConfiguration("moveit_config_file")
+    autostart_motion_planner = LaunchConfiguration("autostart_motion_planner")
 
     planner_server_params = PathJoinSubstitution(
         [
@@ -149,7 +150,7 @@ def launch_setup(context, *args, **kwargs):
     )
 
     # Start the nexus_motion_planner server
-    motion_planner = Node(
+    motion_planner = LifecycleNode(
         package = "nexus_motion_planner",
         executable = "motion_planner_server",
         name = "motion_planner_server",
@@ -160,6 +161,7 @@ def launch_setup(context, *args, **kwargs):
           kinematics_yaml,
           planner_server_params,
         ],
+        autostart=autostart_motion_planner.perform(context).lower() == "true",
     )
 
     # RViz
@@ -270,6 +272,13 @@ def generate_launch_description():
             "publish_item",
             default_value="true",
             description="Publish the static transform for item",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "autostart_motion_planner",
+            default_value="false",
+            description="Automatically start the motion planner lifecycle node",
         )
     )
     return LaunchDescription(


### PR DESCRIPTION
I have removed the manual `activate_node` function from `inter_workcell.launch.py` and `nexus_calibration.launch.py` and added the new autostart parameter. I have also removed the `activate_node_service` function from `workcell.launch.py` and integrated the autostart parameter for the `motion_planner_server` in `demo_planner_server.launch.py`. 