### PR TITLE
Inject backward_ros

### DIFF
--- a/nexus_calibration/CMakeLists.txt
+++ b/nexus_calibration/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 set(dep_pkgs
+  backward_ros
   nexus_endpoints
   rclcpp
   rclcpp_components

--- a/nexus_calibration/package.xml
+++ b/nexus_calibration/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>backward_ros</depend>
   <depend>nexus_endpoints</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/nexus_capabilities/CMakeLists.txt
+++ b/nexus_capabilities/CMakeLists.txt
@@ -10,6 +10,7 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 set(dep_pkgs
+  backward_ros
   behaviortree_cpp_v3
   geometry_msgs
   nexus_common

--- a/nexus_capabilities/package.xml
+++ b/nexus_capabilities/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>backward_ros</depend>
   <depend>behaviortree_cpp_v3</depend>
   <depend>nexus_common</depend>
   <depend>nexus_endpoints</depend>

--- a/nexus_common/CMakeLists.txt
+++ b/nexus_common/CMakeLists.txt
@@ -5,6 +5,7 @@ project(${PROJECT_NAME} VERSION 0.0.1)
 include(GenerateExportHeader)
 
 find_package(ament_cmake REQUIRED)
+find_package(backward_ros REQUIRED)
 find_package(behaviortree_cpp_v3 REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(lifecycle_msgs REQUIRED)

--- a/nexus_common/package.xml
+++ b/nexus_common/package.xml
@@ -7,6 +7,7 @@
   <maintainer email="koonpeng@openrobotics.org">Teo Koon Peng</maintainer>
   <license>Apache License 2.0</license>
 
+  <depend>backward_ros</depend>
   <depend>behaviortree_cpp_v3</depend>
   <depend>geometry_msgs</depend>
   <depend>lifecycle_msgs</depend>

--- a/nexus_demos/CMakeLists.txt
+++ b/nexus_demos/CMakeLists.txt
@@ -3,6 +3,7 @@ set(PROJECT_NAME nexus_demos)
 project(${PROJECT_NAME} VERSION 0.0.1)
 
 find_package(ament_cmake REQUIRED)
+find_package(backward_ros REQUIRED)
 find_package(nexus_endpoints REQUIRED)
 find_package(nexus_transporter REQUIRED)
 find_package(yaml_cpp_vendor REQUIRED)

--- a/nexus_demos/package.xml
+++ b/nexus_demos/package.xml
@@ -13,6 +13,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>ament_index_python</depend>
+  <depend>backward_ros</depend>
   <depend>lifecycle_msgs</depend>
   <depend>pluginlib</depend>
   <depend>nexus_transporter</depend>

--- a/nexus_endpoints/CMakeLists.txt
+++ b/nexus_endpoints/CMakeLists.txt
@@ -3,6 +3,7 @@
 cmake_minimum_required(VERSION 3.16)
 project(nexus_endpoints)
 
+find_package(backward_ros REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_action REQUIRED)
 find_package(ament_cmake REQUIRED)

--- a/nexus_endpoints/package.xml
+++ b/nexus_endpoints/package.xml
@@ -7,6 +7,7 @@
   <maintainer email="koonpeng@openrobotics.org">Teo Koon Peng</maintainer>
   <license>Apache License 2.0</license>
 
+  <depend>backward_ros</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_action</depend>
   <depend>control_msgs</depend>

--- a/nexus_gazebo/CMakeLists.txt
+++ b/nexus_gazebo/CMakeLists.txt
@@ -6,6 +6,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(backward_ros REQUIRED)
 find_package(gz_sim_vendor REQUIRED)
 find_package(gz-sim REQUIRED)
 find_package(VRPN REQUIRED)

--- a/nexus_gazebo/package.xml
+++ b/nexus_gazebo/package.xml
@@ -13,6 +13,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>backward_ros</depend>
   <depend>rclcpp</depend>
   <depend>vrpn</depend>
 

--- a/nexus_lifecycle_manager/CMakeLists.txt
+++ b/nexus_lifecycle_manager/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 project(nexus_lifecycle_manager)
 
 find_package(ament_cmake REQUIRED)
+find_package(backward_ros REQUIRED)
 find_package(behaviortree_cpp_v3 REQUIRED)
 find_package(nexus_common REQUIRED)
 find_package(nexus_lifecycle_msgs REQUIRED)

--- a/nexus_lifecycle_manager/package.xml
+++ b/nexus_lifecycle_manager/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>backward_ros</depend>
   <depend>diagnostic_updater</depend>
   <depend>nexus_common</depend>
   <depend>nexus_cmake</depend>

--- a/nexus_motion_planner/CMakeLists.txt
+++ b/nexus_motion_planner/CMakeLists.txt
@@ -7,6 +7,7 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
+find_package(backward_ros REQUIRED)
 find_package(nexus_endpoints REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(moveit_ros_planning_interface REQUIRED)

--- a/nexus_motion_planner/package.xml
+++ b/nexus_motion_planner/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>backward_ros</depend>
   <depend>nexus_endpoints</depend>
   <depend>geometry_msgs</depend>
   <depend>moveit_ros_planning_interface</depend>

--- a/nexus_robot_controller/CMakeLists.txt
+++ b/nexus_robot_controller/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(nexus_robot_controller)
 
 find_package(ament_cmake REQUIRED)
+find_package(backward_ros REQUIRED)
 find_package(controller_manager REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)

--- a/nexus_robot_controller/package.xml
+++ b/nexus_robot_controller/package.xml
@@ -19,6 +19,8 @@
   <build_depend>ros2_control</build_depend>
   <build_depend>std_msgs</build_depend>
 
+  <depend>backward_ros</depend>
+
   <exec_depend>behaviortree_cpp_v3</exec_depend>
   <exec_depend>control_msgs</exec_depend>
   <exec_depend>controller_manager</exec_depend>

--- a/nexus_rviz_plugins/CMakeLists.txt
+++ b/nexus_rviz_plugins/CMakeLists.txt
@@ -7,6 +7,7 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
+find_package(backward_ros REQUIRED)
 find_package(behaviortree_cpp_v3 REQUIRED)
 find_package(nexus_endpoints REQUIRED)
 find_package(nexus_lifecycle_manager REQUIRED)

--- a/nexus_rviz_plugins/package.xml
+++ b/nexus_rviz_plugins/package.xml
@@ -8,6 +8,7 @@
   <license>Apache-2.0</license>
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>backward_ros</depend>
   <depend>rviz_common</depend>
   <depend>nexus_endpoints</depend>
   <depend>nexus_lifecycle_manager</depend>

--- a/nexus_system_orchestrator/CMakeLists.txt
+++ b/nexus_system_orchestrator/CMakeLists.txt
@@ -3,6 +3,7 @@ set(PROJECT_NAME nexus_system_orchestrator)
 project(${PROJECT_NAME} VERSION 0.0.1)
 
 find_package(ament_cmake REQUIRED)
+find_package(backward_ros REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_action REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)

--- a/nexus_system_orchestrator/package.xml
+++ b/nexus_system_orchestrator/package.xml
@@ -7,6 +7,7 @@
   <maintainer email="koonpeng@openrobotics.org">Teo Koon Peng</maintainer>
   <license>Apache License 2.0</license>
 
+  <depend>backward_ros</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_action</depend>
   <depend>rclcpp_lifecycle</depend>

--- a/nexus_transporter/CMakeLists.txt
+++ b/nexus_transporter/CMakeLists.txt
@@ -10,6 +10,7 @@ include(GNUInstallDirs)
 # find dependencies
 find_package(ament_cmake REQUIRED)
 set(dep_pkgs
+  backward_ros
   nexus_endpoints
   nexus_transporter_msgs
   geometry_msgs

--- a/nexus_transporter/package.xml
+++ b/nexus_transporter/package.xml
@@ -12,6 +12,7 @@
   <depend>nexus_endpoints</depend>
   <depend>nexus_transporter_msgs</depend>
 
+  <depend>backward_ros</depend>
   <depend>geometry_msgs</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>

--- a/nexus_workcell_orchestrator/CMakeLists.txt
+++ b/nexus_workcell_orchestrator/CMakeLists.txt
@@ -3,6 +3,7 @@ set(PROJECT_NAME nexus_workcell_orchestrator)
 project(${PROJECT_NAME})
 
 find_package(ament_cmake REQUIRED)
+find_package(backward_ros REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_action REQUIRED)

--- a/nexus_workcell_orchestrator/package.xml
+++ b/nexus_workcell_orchestrator/package.xml
@@ -15,6 +15,7 @@
   <build_depend>rclcpp_components</build_depend>
   <build_depend>rmf_utils</build_depend>
 
+  <depend>backward_ros</depend>
   <depend>behaviortree_cpp_v3</depend>
   <depend>geometry_msgs</depend>
   <depend>pluginlib</depend>


### PR DESCRIPTION
Was running some scenarios and saw crashes with workcell orchestrator. Adding [backwards_ros](https://github.com/pal-robotics/backward_ros) to automatically dump stack traces for easier debugging. 