### PR TITLE
Allow certain BT nodes to be blocklisted for logging

### DIFF
--- a/nexus_demos/launch/inter_workcell.launch.py
+++ b/nexus_demos/launch/inter_workcell.launch.py
@@ -33,6 +33,8 @@ from launch.actions import (
 from launch.conditions import IfCondition, UnlessCondition
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 
+from typing import List
+
 
 def activate_node(target_node: LifecycleNode, depend_node: LifecycleNode = None):
 
@@ -120,6 +122,10 @@ def launch_setup(context, *args, **kwargs):
     nexus_rviz_config = LaunchConfiguration("nexus_rviz_config")
     system_orchestrator_bt_dir = LaunchConfiguration("system_orchestrator_bt_dir")
     max_jobs = LaunchConfiguration("max_jobs")
+    # todo(Yadunund): There is no good way to get a list of strings via CLI and parse it using
+    # LaunchConfiguration. The best way to configure this would be via a YAML params which we
+    # pass to this node.
+    bt_logging_blocklist : List[str] = ["IsPauseTriggered"]
 
     system_orchestrator_node = LifecycleNode(
         name="system_orchestrator",
@@ -129,6 +135,7 @@ def launch_setup(context, *args, **kwargs):
         parameters=[
             {
                 "bt_path": system_orchestrator_bt_dir,
+                "bt_logging_blocklist": ParameterValue(bt_logging_blocklist, value_type=List[str]),
                 "remap_task_types": ParameterValue(remap_task_types, value_type=str),
                 "main_bt_filename": main_bt_filename,
                 "max_jobs": max_jobs,

--- a/nexus_demos/launch/workcell.launch.py
+++ b/nexus_demos/launch/workcell.launch.py
@@ -37,6 +37,9 @@ from launch.event_handlers import OnProcessExit
 from launch.events import Shutdown
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution, FindExecutable
 
+from typing import List
+
+
 def activate_node_service(node_name, ros_domain_id):
     activate_node_proc = ExecuteProcess(
         cmd=[
@@ -96,6 +99,10 @@ def launch_setup(context, *args, **kwargs):
     zenoh_config_package = LaunchConfiguration("zenoh_config_package")
     zenoh_config_filename = LaunchConfiguration("zenoh_config_filename")
     remap_task_types = LaunchConfiguration("remap_task_types")
+    # todo(Yadunund): There is no good way to get a list of strings via CLI and parse it using
+    # LaunchConfiguration. The best way to configure this would be via a YAML params which we
+    # pass to this node.
+    bt_logging_blocklist : List[str] = ["IsPauseTriggered"]
 
     workcell_id_str = workcell_id.perform(context)
 
@@ -187,6 +194,7 @@ def launch_setup(context, *args, **kwargs):
             ),
             Parameter("gripper_max_effort", 0.0),
             Parameter("remap_task_types", remap_task_types),
+            Parameter("bt_logging_blocklist", bt_logging_blocklist),
         ],
         arguments=['--ros-args', '--log-level', 'info'],
     )

--- a/nexus_workcell_orchestrator/src/workcell_orchestrator.cpp
+++ b/nexus_workcell_orchestrator/src/workcell_orchestrator.cpp
@@ -154,6 +154,14 @@ WorkcellOrchestrator::WorkcellOrchestrator(const rclcpp::NodeOptions& options)
     this->_max_parallel_jobs = this->get_parameter("max_jobs").as_int();
   }
 
+  {
+    ParameterDescriptor desc;
+    desc.read_only = true;
+    desc.description =
+      "A list of BT node names whose state changes should not be logged.";
+    this->declare_parameter("bt_logging_blocklist", std::vector<std::string>{}, desc);
+  }
+
   this->_register_workcell_client =
     this->create_client<endpoints::RegisterWorkcellService::ServiceType>(
     endpoints::RegisterWorkcellService::service_name());
@@ -391,8 +399,10 @@ auto WorkcellOrchestrator::_configure(
         ctx->task_state.workcell_id = this->get_name();
         ctx->task_state.task_id = ctx->task.task_id;
         ctx->bt = this->_create_bt(ctx);
-        ctx->bt_logging = std::make_unique<common::BtLogging>(ctx->bt,
-        this->shared_from_this());
+        ctx->bt_logging = std::make_unique<common::BtLogging>(
+          ctx->bt,
+          this->shared_from_this(),
+          this->get_parameter("bt_logging_blocklist").as_string_array());
       }
       catch (const std::exception& e)
       {


### PR DESCRIPTION
Stopgap solution for #59.

This PR updates the `BTLogging` class to accept a list of nodes that that we want to blocklist for logging.

Also updates system and workcell orchestrators to get these node names via a `bt_logging_blocklist` param. The launch file s are updated set this param to blocklist `IsPauseTriggered` which prevents terminal spam when running a process.