### PR TITLE
Input and output items for steps

### DIFF
--- a/.github/workflows/nexus_integration_tests.yaml
+++ b/.github/workflows/nexus_integration_tests.yaml
@@ -37,10 +37,10 @@ jobs:
         rosdep install --from-paths . -yir
     - name: build
       run: /ros_entrypoint.sh colcon build --packages-up-to nexus_calibration nexus_gazebo nexus_demos nexus_motion_planner --mixin release lld --cmake-args -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-    - name: Test - Integration Test
+    - name: Test - Demos unit tests and integration tests
       uses: nick-fields/retry@v3
       with:
         timeout_minutes: 20
         max_attempts: 3
         retry_on: error
-        command: . ./install/setup.bash && cd nexus_demos && RMW_IMPLEMENTATION=rmw_cyclonedds_cpp /ros_entrypoint.sh python3 -m unittest
+        command: . ./install/setup.bash && RMW_IMPLEMENTATION=rmw_cyclonedds_cpp /ros_entrypoint.sh colcon test --packages-select nexus_demos --event-handlers=console_direct+ --parallel-workers 1

--- a/.github/workflows/nexus_integration_tests.yaml
+++ b/.github/workflows/nexus_integration_tests.yaml
@@ -43,4 +43,4 @@ jobs:
         timeout_minutes: 20
         max_attempts: 3
         retry_on: error
-        command: . ./install/setup.bash && RMW_IMPLEMENTATION=rmw_cyclonedds_cpp /ros_entrypoint.sh colcon test --packages-select nexus_motion_planner nexus_demos --event-handlers=console_direct+ --parallel-workers 1
+        command: . ./install/setup.bash && RMW_IMPLEMENTATION=rmw_cyclonedds_cpp /ros_entrypoint.sh colcon test --packages-select nexus_motion_planner nexus_demos --event-handlers console_direct+ --parallel-workers 1

--- a/.github/workflows/nexus_integration_tests.yaml
+++ b/.github/workflows/nexus_integration_tests.yaml
@@ -43,4 +43,4 @@ jobs:
         timeout_minutes: 20
         max_attempts: 3
         retry_on: error
-        command: . ./install/setup.bash && RMW_IMPLEMENTATION=rmw_cyclonedds_cpp /ros_entrypoint.sh colcon test --packages-select nexus_demos --event-handlers=console_direct+ --parallel-workers 1
+        command: . ./install/setup.bash && RMW_IMPLEMENTATION=rmw_cyclonedds_cpp /ros_entrypoint.sh colcon test --packages-select nexus_motion_planner nexus_demos --event-handlers=console_direct+ --parallel-workers 1

--- a/.github/workflows/nexus_integration_tests.yaml
+++ b/.github/workflows/nexus_integration_tests.yaml
@@ -37,8 +37,6 @@ jobs:
         rosdep install --from-paths . -yir
     - name: build
       run: /ros_entrypoint.sh colcon build --packages-up-to nexus_calibration nexus_gazebo nexus_demos nexus_motion_planner --mixin release lld --cmake-args -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-    - name: Test - Unit Tests
-      run: . ./install/setup.bash && RMW_IMPLEMENTATION=rmw_cyclonedds_cpp /ros_entrypoint.sh colcon test --packages-select nexus_motion_planner --event-handlers=console_direct+
     - name: Test - Integration Test
       uses: nick-fields/retry@v3
       with:

--- a/.github/workflows/nexus_unit_tests.yaml
+++ b/.github/workflows/nexus_unit_tests.yaml
@@ -37,3 +37,4 @@ jobs:
             nexus_workcell_orchestrator
           target-ros2-distro: ${{ matrix.ros_distribution }}
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
+          vcs-repo-file-url: https://raw.githubusercontent.com/osrf/nexus/main/abb.repos

--- a/.github/workflows/nexus_unit_tests.yaml
+++ b/.github/workflows/nexus_unit_tests.yaml
@@ -33,7 +33,6 @@ jobs:
           package-name: |
             nexus_common
             nexus_lifecycle_manager
-            nexus_motion_planner
             nexus_system_orchestrator
             nexus_transporter
             nexus_workcell_orchestrator

--- a/.github/workflows/nexus_unit_tests.yaml
+++ b/.github/workflows/nexus_unit_tests.yaml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: ros-tooling/setup-ros@v0.7
         with:
-          required-ros-distributions: ${{ inputs.ros-distribution }}
+          required-ros-distributions: ${{ matrix.ros_distribution }}
 
       - name: build and test
         uses: ros-tooling/action-ros-ci@v0.3

--- a/.github/workflows/nexus_unit_tests.yaml
+++ b/.github/workflows/nexus_unit_tests.yaml
@@ -28,6 +28,12 @@ jobs:
       - name: build and test
         uses: ros-tooling/action-ros-ci@v0.3
         with:
-          package-name: nexus_common nexus_motion_planner
-          target-ros2-distro: ${{ inputs.ros-distribution }}
+          package-name: |
+            nexus_common
+            nexus_lifecycle_manager
+            nexus_motion_planner
+            nexus_system_orchestrator
+            nexus_transporter
+            nexus_workcell_orchestrator
+          target-ros2-distro: ${{ matrix.ros_distribution }}
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml

--- a/.github/workflows/nexus_unit_tests.yaml
+++ b/.github/workflows/nexus_unit_tests.yaml
@@ -25,6 +25,9 @@ jobs:
         with:
           required-ros-distributions: ${{ matrix.ros_distribution }}
 
+      # Only tests that can be run without arbitrary number of workers. For
+      # tests that require --parallel-workers 1, run it in
+      # nexus_integration_tests.
       - name: build and test
         uses: ros-tooling/action-ros-ci@v0.3
         env:

--- a/.github/workflows/nexus_unit_tests.yaml
+++ b/.github/workflows/nexus_unit_tests.yaml
@@ -1,0 +1,33 @@
+name: nexus_unit_tests
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+defaults:
+  run:
+    shell: bash
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: ros:${{ matrix.ros_distribution }}-ros-base
+    strategy:
+      fail-fast: false
+      matrix:
+        ros_distribution:
+          - jazzy
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - uses: ros-tooling/setup-ros@v0.7
+        with:
+          required-ros-distributions: ${{ inputs.ros-distribution }}
+
+      - name: build and test
+        uses: ros-tooling/action-ros-ci@v0.3
+        with:
+          package-name: nexus_common nexus_motion_planner
+          target-ros2-distro: ${{ inputs.ros-distribution }}
+          colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml

--- a/.github/workflows/nexus_unit_tests.yaml
+++ b/.github/workflows/nexus_unit_tests.yaml
@@ -27,6 +27,8 @@ jobs:
 
       - name: build and test
         uses: ros-tooling/action-ros-ci@v0.3
+        env:
+          RMW_IMPLEMENTATION: rmw_cyclonedds_cpp
         with:
           package-name: |
             nexus_common

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 /thirdparty/
 .vscode/
 *.ikcache
+**/*.rmf_schedule_node.yaml

--- a/nexus_common/CMakeLists.txt
+++ b/nexus_common/CMakeLists.txt
@@ -90,13 +90,12 @@ if(BUILD_TESTING)
     NAMES "rmf_code_style.cfg"
     PATHS "${rmf_utils_DIR}/../../../../share/rmf_utils/")
 
-  # TODO(luca) Add uncrustify back after formatting
-  #ament_uncrustify(
-  #  ARGN include src
-  #  CONFIG_FILE ${uncrustify_config_file}
-  #  MAX_LINE_LENGTH 80
-  #  LANGUAGE CPP
-  #)
+  ament_uncrustify(
+    ARGN include src
+    CONFIG_FILE ${uncrustify_config_file}
+    MAX_LINE_LENGTH 80
+    LANGUAGE CPP
+  )
 
   # Adds a ament catch2 test with some common libraries.
   # Usage: nexus_add_test(<target> <source>...)

--- a/nexus_common/CMakeLists.txt
+++ b/nexus_common/CMakeLists.txt
@@ -123,6 +123,7 @@ if(BUILD_TESTING)
   nexus_add_test(service_client_bt_node_test src/service_client_bt_node_test.cpp)
   nexus_add_test(models_test
     src/main_test.cpp
+    src/models/item_test.cpp
     src/models/work_order_test.cpp
   )
   nexus_add_test(ros_utils_test

--- a/nexus_common/include/nexus_common/action_client_bt_node.hpp
+++ b/nexus_common/include/nexus_common/action_client_bt_node.hpp
@@ -79,7 +79,8 @@ protected: virtual void on_feedback(typename ActionT::Feedback::ConstSharedPtr);
    * the action is considered a success and false otherwise.
    */
 protected: virtual bool on_result(
-    const typename rclcpp_action::ClientGoalHandle<ActionT>::WrappedResult& result);
+    const typename rclcpp_action::ClientGoalHandle<ActionT>::WrappedResult&
+    result);
 
 private: rclcpp::executors::SingleThreadedExecutor _executor;
 private: rclcpp::CallbackGroup::SharedPtr _cb_group;
@@ -131,7 +132,7 @@ BT::NodeStatus ActionClientBtNode<NodePtrT, ActionT>::onStart()
   typename rclcpp_action::Client<ActionT>::SendGoalOptions options;
   options.feedback_callback =
     [this](typename rclcpp_action::ClientGoalHandle<ActionT>::SharedPtr,
-      typename ActionT::Feedback::ConstSharedPtr feedback)
+    typename ActionT::Feedback::ConstSharedPtr feedback)
     {
       this->on_feedback(feedback);
     };

--- a/nexus_common/include/nexus_common/batch_service_call.hpp
+++ b/nexus_common/include/nexus_common/batch_service_call.hpp
@@ -64,7 +64,7 @@ struct BatchServiceResult
  */
 template<typename NodePtrT, typename ServiceT, typename KeyT,
   typename DoneCallbackT = std::function<void(const std::unordered_map<KeyT,
-  BatchServiceResult<ServiceT>>&)>>
+  BatchServiceResult<ServiceT>>& )>>
 CancellationToken batch_service_call(
   NodePtrT node,
   const std::unordered_map<KeyT, BatchServiceReq<ServiceT>>& batch_reqs,

--- a/nexus_common/include/nexus_common/logging.hpp
+++ b/nexus_common/include/nexus_common/logging.hpp
@@ -90,7 +90,7 @@ public: template<typename LogFunctor,
   {
     this->_node_states.reserve(bt.nodes.size());
     std::unordered_set<std::string> blocklist_set;
-    for (const std::string & bn : blocklist_nodes)
+    for (const std::string& bn : blocklist_nodes)
     {
       blocklist_set.insert(bn);
     }
@@ -149,7 +149,8 @@ public: template<typename NodePtrT,
     std::enable_if_t<!std::is_invocable_v<NodePtrT,
     const std::string&>, bool> = true>
   BtLogging(
-    BT::Tree& bt, NodePtrT node, const std::vector<std::string>& blocklist_nodes = {})
+    BT::Tree& bt, NodePtrT node,
+    const std::vector<std::string>& blocklist_nodes = {})
   : BtLogging(bt, RclcppInfoLogF<NodePtrT>(node), blocklist_nodes)
   {}
 

--- a/nexus_common/include/nexus_common/models/item.hpp
+++ b/nexus_common/include/nexus_common/models/item.hpp
@@ -15,22 +15,39 @@
  *
  */
 
-#ifndef NEXUS_COMMON__MODELS__METADATA_HPP
-#define NEXUS_COMMON__MODELS__METADATA_HPP
+#ifndef NEXUS_COMMON__MODELS__ITEM_HPP
+#define NEXUS_COMMON__MODELS__ITEM_HPP
 
+#include <optional>
+
+#include "metadata.hpp"
 #include "../yaml_helpers.hpp"
 
 namespace nexus::common {
 
-class MetaData
+class Item
 {
 public:
   YAML::Node yaml;
 
-  MetaData(YAML::Node yaml)
+  Item(YAML::Node yaml)
   : yaml(std::move(yaml)) {}
 
-  MetaData() {}
+  Item() {}
+
+  std::string guid() const
+  {
+    return this->yaml["guid"].as<std::string>();
+  }
+
+  std::optional<MetaData> metadata() const
+  {
+    if (this->yaml["metadata"])
+    {
+      return this->yaml["metadata"];
+    }
+    return std::nullopt;
+  }
 };
 
 }  // namespace nexus::common
@@ -38,14 +55,14 @@ public:
 namespace YAML {
 
 template<>
-struct convert<nexus::common::MetaData>
+struct convert<nexus::common::Item>
 {
-  static Node encode(const nexus::common::MetaData& data)
+  static Node encode(const nexus::common::Item& data)
   {
     return data.yaml;
   }
 
-  static bool decode(const Node& node, nexus::common::MetaData& data)
+  static bool decode(const Node& node, nexus::common::Item& data)
   {
     data.yaml = node;
     return true;
@@ -54,4 +71,4 @@ struct convert<nexus::common::MetaData>
 
 }  // namespace YAML
 
-#endif  // NEXUS_COMMON__MODELS__METADATA_HPP
+#endif  // NEXUS_COMMON__MODELS__ITEM_HPP

--- a/nexus_common/include/nexus_common/models/item.hpp
+++ b/nexus_common/include/nexus_common/models/item.hpp
@@ -19,6 +19,7 @@
 #define NEXUS_COMMON__MODELS__ITEM_HPP
 
 #include <optional>
+#include <stdexcept>
 
 #include "metadata.hpp"
 #include "../yaml_helpers.hpp"
@@ -64,6 +65,11 @@ struct convert<nexus::common::Item>
 
   static bool decode(const Node& node, nexus::common::Item& data)
   {
+    if (!node["guid"] || node["guid"].as<std::string>().empty())
+    {
+      throw std::invalid_argument("missing required [guid] field");
+    }
+
     data.yaml = node;
     return true;
   }

--- a/nexus_common/include/nexus_common/models/work_order.hpp
+++ b/nexus_common/include/nexus_common/models/work_order.hpp
@@ -20,6 +20,7 @@
 
 #include <optional>
 
+#include "item.hpp"
 #include "metadata.hpp"
 #include "../yaml_helpers.hpp"
 
@@ -46,14 +47,24 @@ public: struct Step
       return this->yaml["processParams"];
     }
 
-    std::vector<MetaData> inputs() const
+    std::vector<Item> input_items() const
     {
-      return this->yaml["inputs"].as<std::vector<MetaData>>();
+      if (!this->yaml["inputItems"])
+      {
+        return {};
+      }
+
+      return this->yaml["inputItems"].as<std::vector<Item>>();
     }
 
-    std::vector<MetaData> outputs() const
+    std::vector<Item> output_items() const
     {
-      return this->yaml["outputs"].as<std::vector<MetaData>>();
+      if (!this->yaml["outputItems"])
+      {
+        return {};
+      }
+
+      return this->yaml["outputItems"].as<std::vector<Item>>();
     }
   };
 

--- a/nexus_common/include/nexus_common/models/work_order.hpp
+++ b/nexus_common/include/nexus_common/models/work_order.hpp
@@ -26,7 +26,7 @@
 
 namespace nexus::common {
 
-struct WorkOrder
+class WorkOrder
 {
 public: struct Step
   {
@@ -73,9 +73,9 @@ public: YAML::Node yaml;
 public: WorkOrder(YAML::Node yaml)
   : yaml(std::move(yaml)) {}
 
-  WorkOrder() {}
+public: WorkOrder() {}
 
-  std::string work_instruction_name() const
+public: std::string work_instruction_name() const
   {
     return this->yaml["workInstructionName"].as<std::string>();
   }

--- a/nexus_common/include/nexus_common/models/work_order.hpp
+++ b/nexus_common/include/nexus_common/models/work_order.hpp
@@ -19,6 +19,7 @@
 #define NEXUS_COMMON__MODELS__WORK_ORDER_HPP
 
 #include <optional>
+#include <stdexcept>
 
 #include "item.hpp"
 #include "metadata.hpp"
@@ -110,6 +111,11 @@ struct convert<nexus::common::WorkOrder::Step>
   static bool decode(const Node& node,
     nexus::common::WorkOrder::Step& data)
   {
+    if (!node["processId"] || node["processId"].as<std::string>().empty())
+    {
+      throw std::invalid_argument("missing required [processId] field");
+    }
+
     data.yaml = node;
     return true;
   }
@@ -125,6 +131,18 @@ struct convert<nexus::common::WorkOrder>
 
   static bool decode(const Node& node, nexus::common::WorkOrder& data)
   {
+    if (!node["workInstructionName"] ||
+      node["workInstructionName"].as<std::string>().empty())
+    {
+      throw std::invalid_argument(
+              "missing required [workInstructionName] field");
+    }
+    if (!node["steps"] ||
+      node["steps"].as<std::vector<nexus::common::WorkOrder::Step>>().empty())
+    {
+      throw std::invalid_argument("missing required [steps] field");
+    }
+
     data.yaml = node;
     return true;
   }

--- a/nexus_common/include/nexus_common/models/work_order.hpp
+++ b/nexus_common/include/nexus_common/models/work_order.hpp
@@ -95,7 +95,7 @@ public: std::vector<Step> steps() const
   }
 };
 
-} // namespace nexus::common
+}  // namespace nexus::common
 
 namespace YAML {
 
@@ -130,6 +130,6 @@ struct convert<nexus::common::WorkOrder>
   }
 };
 
-} // namespace YAML
+}  // namespace YAML
 
-#endif // NEXUS_COMMON__MODELS__WORK_ORDER_HPP
+#endif  // NEXUS_COMMON__MODELS__WORK_ORDER_HPP

--- a/nexus_common/include/nexus_common/models/work_order.hpp
+++ b/nexus_common/include/nexus_common/models/work_order.hpp
@@ -25,7 +25,7 @@
 
 namespace nexus::common {
 
-class WorkOrder
+struct WorkOrder
 {
 public: struct Step
   {
@@ -46,6 +46,15 @@ public: struct Step
       return this->yaml["processParams"];
     }
 
+    std::vector<MetaData> inputs() const
+    {
+      return this->yaml["inputs"].as<std::vector<MetaData>>();
+    }
+
+    std::vector<MetaData> outputs() const
+    {
+      return this->yaml["outputs"].as<std::vector<MetaData>>();
+    }
   };
 
 public: YAML::Node yaml;
@@ -53,9 +62,9 @@ public: YAML::Node yaml;
 public: WorkOrder(YAML::Node yaml)
   : yaml(std::move(yaml)) {}
 
-public: WorkOrder() {}
+  WorkOrder() {}
 
-public: std::string work_instruction_name() const
+  std::string work_instruction_name() const
   {
     return this->yaml["workInstructionName"].as<std::string>();
   }
@@ -74,7 +83,7 @@ public: std::vector<Step> steps() const
   }
 };
 
-}
+} // namespace nexus::common
 
 namespace YAML {
 
@@ -109,6 +118,6 @@ struct convert<nexus::common::WorkOrder>
   }
 };
 
-}
+} // namespace YAML
 
-#endif
+#endif // NEXUS_COMMON__MODELS__WORK_ORDER_HPP

--- a/nexus_common/include/nexus_common/models/work_order.hpp
+++ b/nexus_common/include/nexus_common/models/work_order.hpp
@@ -71,9 +71,10 @@ public: WorkOrder(YAML::Node yaml)
 
 public: std::optional<MetaData> metadata() const
   {
-    if (this->yaml["metadata"]) {
+    if (this->yaml["metadata"])
+    {
       return this->yaml["metadata"];
-    };
+    }
     return std::nullopt;
   }
 

--- a/nexus_common/package.xml
+++ b/nexus_common/package.xml
@@ -28,6 +28,7 @@
   <test_depend>ament_cmake_uncrustify</test_depend>
   <test_depend>example_interfaces</test_depend>
   <test_depend>std_msgs</test_depend>
+  <test_depend>rmw_cyclonedds_cpp</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/nexus_common/src/action_client_bt_node_test.cpp
+++ b/nexus_common/src/action_client_bt_node_test.cpp
@@ -44,7 +44,8 @@ public: static BT::PortsList providedPorts()
 
 public: TestActionBtNode(const std::string& name,
     const BT::NodeConfiguration& config, rclcpp::Node::SharedPtr node,
-    rclcpp_action::Client<example_interfaces::action::Fibonacci>::SharedPtr client)
+    rclcpp_action::Client<example_interfaces::action::Fibonacci>::SharedPtr
+    client)
   : ActionClientBtNode<rclcpp::Node::SharedPtr,
       example_interfaces::action::Fibonacci>(name, config, node),
     _client(client) {}
@@ -116,13 +117,15 @@ TEST_CASE("ActionClientBtNode", "[BehaviorTree]")
         return rclcpp_action::GoalResponse::REJECT;
       },
       [&](
-        std::shared_ptr<rclcpp_action::ServerGoalHandle<example_interfaces::action::Fibonacci>>)
+        std::shared_ptr<rclcpp_action::ServerGoalHandle<example_interfaces::
+        action::Fibonacci>>)
       {
         rejected_goal.set_value();
         return rclcpp_action::CancelResponse::REJECT;
       },
       [](
-        std::shared_ptr<rclcpp_action::ServerGoalHandle<example_interfaces::action::Fibonacci>>
+        std::shared_ptr<rclcpp_action::ServerGoalHandle<example_interfaces::
+        action::Fibonacci>>
         handle)
       {
         handle->abort(
@@ -145,12 +148,14 @@ TEST_CASE("ActionClientBtNode", "[BehaviorTree]")
         return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
       },
       [](
-        std::shared_ptr<rclcpp_action::ServerGoalHandle<example_interfaces::action::Fibonacci>>)
+        std::shared_ptr<rclcpp_action::ServerGoalHandle<example_interfaces::
+        action::Fibonacci>>)
       {
         return rclcpp_action::CancelResponse::REJECT;
       },
       [](
-        std::shared_ptr<rclcpp_action::ServerGoalHandle<example_interfaces::action::Fibonacci>>
+        std::shared_ptr<rclcpp_action::ServerGoalHandle<example_interfaces::
+        action::Fibonacci>>
         handle)
       {
         handle->abort(
@@ -178,13 +183,15 @@ TEST_CASE("ActionClientBtNode", "[BehaviorTree]")
         return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
       },
       [&](
-        std::shared_ptr<rclcpp_action::ServerGoalHandle<example_interfaces::action::Fibonacci>>)
+        std::shared_ptr<rclcpp_action::ServerGoalHandle<example_interfaces::
+        action::Fibonacci>>)
       {
         got_cancel.set_value();
         return rclcpp_action::CancelResponse::ACCEPT;
       },
       [&](
-        std::shared_ptr<rclcpp_action::ServerGoalHandle<example_interfaces::action::Fibonacci>>
+        std::shared_ptr<rclcpp_action::ServerGoalHandle<example_interfaces::
+        action::Fibonacci>>
         handle)
       {
         started_job.set_value();
@@ -202,7 +209,7 @@ TEST_CASE("ActionClientBtNode", "[BehaviorTree]")
     tick_until(bt, [&](auto)
       {
         return started_job_fut.wait_for(std::chrono::seconds(
-          0)) == std::future_status::ready;
+            0)) == std::future_status::ready;
       }, std::chrono::seconds(1));
     bt.haltTree();
     CHECK(got_cancel_fut.wait_for(std::chrono::seconds(0)) ==
@@ -225,12 +232,14 @@ TEST_CASE("ActionClientBtNode", "[BehaviorTree]")
         return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
       },
       [&](
-        std::shared_ptr<rclcpp_action::ServerGoalHandle<example_interfaces::action::Fibonacci>>)
+        std::shared_ptr<rclcpp_action::ServerGoalHandle<example_interfaces::
+        action::Fibonacci>>)
       {
         return rclcpp_action::CancelResponse::REJECT;
       },
       [&](
-        std::shared_ptr<rclcpp_action::ServerGoalHandle<example_interfaces::action::Fibonacci>>
+        std::shared_ptr<rclcpp_action::ServerGoalHandle<example_interfaces::
+        action::Fibonacci>>
         handle)
       {
         started_job.set_value();
@@ -247,7 +256,7 @@ TEST_CASE("ActionClientBtNode", "[BehaviorTree]")
     tick_until(bt, [&](auto)
       {
         return started_job_fut.wait_for(std::chrono::seconds(
-          0)) == std::future_status::ready;
+            0)) == std::future_status::ready;
       }, std::chrono::seconds(1));
 
     // test action takes 1 second, halting the tree should cause it to block until
@@ -270,12 +279,14 @@ TEST_CASE("ActionClientBtNode", "[BehaviorTree]")
         return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
       },
       [](
-        std::shared_ptr<rclcpp_action::ServerGoalHandle<example_interfaces::action::Fibonacci>>)
+        std::shared_ptr<rclcpp_action::ServerGoalHandle<example_interfaces::
+        action::Fibonacci>>)
       {
         return rclcpp_action::CancelResponse::REJECT;
       },
       [](
-        std::shared_ptr<rclcpp_action::ServerGoalHandle<example_interfaces::action::Fibonacci>>
+        std::shared_ptr<rclcpp_action::ServerGoalHandle<example_interfaces::
+        action::Fibonacci>>
         handle)
       {
         handle->succeed(

--- a/nexus_common/src/models/item_test.cpp
+++ b/nexus_common/src/models/item_test.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2025 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <nexus_common/models/item.hpp>
+#include <rmf_utils/catch.hpp>
+
+#include <yaml-cpp/yaml.h>
+
+namespace nexus::common::test {
+
+TEST_CASE("Item serialization with metadata")
+{
+  std::string raw{
+    R"RAW(
+      {
+        "guid": "1001",
+        "metadata": {
+          "description": "dummy_sku",
+          "unit": "dummy_unit",
+          "quantity": 1,
+          "quantityPerPallet": 1
+        }
+      }
+  )RAW"};
+
+  auto check_data = [](const Item& item)
+  {
+    CHECK(item.guid() == "1001");
+    const auto maybe_metadata = item.metadata();
+    REQUIRE(maybe_metadata.has_value());
+    const auto metadata = maybe_metadata.value();
+    CHECK(metadata.yaml["description"].as<std::string>() == "dummy_sku");
+    CHECK(metadata.yaml["unit"].as<std::string>() == "dummy_unit");
+    CHECK(metadata.yaml["quantity"].as<int>() == 1);
+    CHECK(metadata.yaml["quantityPerPallet"].as<int>() == 1);
+  };
+
+  auto item = YAML::Load(raw).as<Item>();
+  check_data(item);
+
+  YAML::Emitter out;
+  raw = (out << YAML::Node{item}).c_str();
+  item = YAML::Load(raw).as<Item>();
+  check_data(item);
+}
+
+
+} // namespace nexus::common::test

--- a/nexus_common/src/models/item_test.cpp
+++ b/nexus_common/src/models/item_test.cpp
@@ -58,5 +58,4 @@ TEST_CASE("Item serialization with metadata")
   check_data(item);
 }
 
-
-} // namespace nexus::common::test
+}  // namespace nexus::common::test

--- a/nexus_common/src/models/item_test.cpp
+++ b/nexus_common/src/models/item_test.cpp
@@ -20,6 +20,8 @@
 
 #include <yaml-cpp/yaml.h>
 
+#include <stdexcept>
+
 namespace nexus::common::test {
 
 TEST_CASE("Item serialization with metadata")
@@ -56,6 +58,32 @@ TEST_CASE("Item serialization with metadata")
   raw = (out << YAML::Node{item}).c_str();
   item = YAML::Load(raw).as<Item>();
   check_data(item);
+}
+
+TEST_CASE("Item serialization without guid")
+{
+  std::string raw{
+    R"RAW(
+      {
+        "metadata": {
+          "description": "dummy_sku",
+          "unit": "dummy_unit",
+          "quantity": 1,
+          "quantityPerPallet": 1
+        }
+      }
+  )RAW"};
+
+  bool invalid_argument = false;
+  try
+  {
+    auto item = YAML::Load(raw).as<Item>();
+  }
+  catch (const std::invalid_argument& e)
+  {
+    invalid_argument = true;
+  }
+  CHECK(invalid_argument);
 }
 
 }  // namespace nexus::common::test

--- a/nexus_common/src/models/work_order_test.cpp
+++ b/nexus_common/src/models/work_order_test.cpp
@@ -57,35 +57,35 @@ TEST_CASE("WorkOrder serialization with metadata and process params",
   )RAW"};
 
   auto check_data = [](const WorkOrder& work_order)
-    {
-      CHECK(work_order.work_instruction_name() == "CV-299 (Rev 4)");
-      const auto maybe_metadata = work_order.metadata();
-      REQUIRE(maybe_metadata.has_value());
-      const auto metadata = maybe_metadata.value();
-      CHECK(metadata.yaml["SkuId"].as<std::string>() == "1001");
-      CHECK(metadata.yaml["description"].as<std::string>() == "dummy_sku");
-      CHECK(metadata.yaml["unit"].as<std::string>() == "dummy_unit");
-      CHECK(metadata.yaml["quantity"].as<int>() == 1);
-      CHECK(metadata.yaml["quantityPerPallet"].as<int>() == 1);
-      REQUIRE(work_order.steps().size() == 3);
+  {
+    CHECK(work_order.work_instruction_name() == "CV-299 (Rev 4)");
+    const auto maybe_metadata = work_order.metadata();
+    REQUIRE(maybe_metadata.has_value());
+    const auto metadata = maybe_metadata.value();
+    CHECK(metadata.yaml["SkuId"].as<std::string>() == "1001");
+    CHECK(metadata.yaml["description"].as<std::string>() == "dummy_sku");
+    CHECK(metadata.yaml["unit"].as<std::string>() == "dummy_unit");
+    CHECK(metadata.yaml["quantity"].as<int>() == 1);
+    CHECK(metadata.yaml["quantityPerPallet"].as<int>() == 1);
+    REQUIRE(work_order.steps().size() == 3);
 
-      const auto steps = work_order.steps();
+    const auto steps = work_order.steps();
 
-      const auto step1 = steps[0];
-      CHECK(step1.process_id() == "pickup");
-      const auto & step1_params = step1.process_params();
-      REQUIRE(step1_params);
-      CHECK(step1_params["param1"].as<int>() == 10);
-      CHECK(step1_params["param2"].as<std::string>() == "base_link");
+    const auto step1 = steps[0];
+    CHECK(step1.process_id() == "pickup");
+    const auto& step1_params = step1.process_params();
+    REQUIRE(step1_params);
+    CHECK(step1_params["param1"].as<int>() == 10);
+    CHECK(step1_params["param2"].as<std::string>() == "base_link");
 
-      const auto& step2 = steps[1];
-      CHECK(step2.process_id() == "place");
-      CHECK_FALSE(step2.process_params());
+    const auto& step2 = steps[1];
+    CHECK(step2.process_id() == "place");
+    CHECK_FALSE(step2.process_params());
 
-      const auto& step3 = steps[2];
-      CHECK(step3.process_id() == "inspect");
-      CHECK_FALSE(step3.process_params());
-    };
+    const auto& step3 = steps[2];
+    CHECK(step3.process_id() == "inspect");
+    CHECK_FALSE(step3.process_params());
+  };
 
   auto work_order = YAML::Load(raw).as<WorkOrder>();
   check_data(work_order);
@@ -117,23 +117,23 @@ TEST_CASE("WorkOrder serialization without metadata", "[Model][Serialization]")
   )RAW"};
 
   auto check_data = [](const WorkOrder& work_order)
-    {
-      CHECK(work_order.work_instruction_name() == "CV-299 (Rev 4)");
-      const auto maybe_metadata = work_order.metadata();
-      REQUIRE_FALSE(maybe_metadata.has_value());
-      REQUIRE(work_order.steps().size() == 3);
+  {
+    CHECK(work_order.work_instruction_name() == "CV-299 (Rev 4)");
+    const auto maybe_metadata = work_order.metadata();
+    REQUIRE_FALSE(maybe_metadata.has_value());
+    REQUIRE(work_order.steps().size() == 3);
 
     const auto steps = work_order.steps();
 
-      const auto step1 = steps[0];
-      CHECK(step1.process_id() == "pickup");
+    const auto step1 = steps[0];
+    CHECK(step1.process_id() == "pickup");
 
-      const auto& step2 = steps[1];
-      CHECK(step2.process_id() == "place");
+    const auto& step2 = steps[1];
+    CHECK(step2.process_id() == "place");
 
-      const auto& step3 = steps[2];
-      CHECK(step3.process_id() == "inspect");
-    };
+    const auto& step3 = steps[2];
+    CHECK(step3.process_id() == "inspect");
+  };
 
   auto work_order = YAML::Load(raw).as<WorkOrder>();
   check_data(work_order);

--- a/nexus_common/src/models/work_order_test.cpp
+++ b/nexus_common/src/models/work_order_test.cpp
@@ -21,6 +21,7 @@
 #include <yaml-cpp/yaml.h>
 
 #include <unordered_set>
+#include <stdexcept>
 
 namespace nexus::common::test {
 
@@ -232,6 +233,105 @@ TEST_CASE("WorkOrder serialization without metadata", "[Model][Serialization]")
   raw = (out << YAML::Node{work_order}).c_str();
   work_order = YAML::Load(raw).as<WorkOrder>();
   check_data(work_order);
+}
+
+TEST_CASE("Step serialization without processId", "[Model][Serialization]")
+{
+  std::string raw{
+    R"RAW(
+      {
+        "processParams": {
+          "param1": 10,
+          "param2": "base_link"
+        }
+      }
+  )RAW"};
+
+  bool invalid_argument = false;
+  try
+  {
+    auto step = YAML::Load(raw).as<WorkOrder::Step>();
+  }
+  catch (const std::invalid_argument& e)
+  {
+    invalid_argument = true;
+  }
+  CHECK(invalid_argument);
+}
+
+TEST_CASE("WorkOrder serialization without workInstructionName",
+  "[Model][Serialization]")
+{
+  std::string raw{
+    R"RAW(
+      {
+        "steps": [
+          {
+            "processId": "pickup"
+          },
+          {
+            "processId": "place"
+          },
+          {
+            "processId": "inspect"
+          }
+        ]
+      }
+  )RAW"};
+
+  bool invalid_argument = false;
+  try
+  {
+    auto work_order = YAML::Load(raw).as<WorkOrder>();
+  }
+  catch (const std::invalid_argument& e)
+  {
+    invalid_argument = true;
+  }
+  CHECK(invalid_argument);
+}
+
+TEST_CASE("WorkOrder serialization without steps", "[Model][Serialization]")
+{
+  std::string raw{
+    R"RAW(
+      {
+        "workInstructionName": "CV-299 (Rev 4)"
+      }
+  )RAW"};
+
+  bool invalid_argument = false;
+  try
+  {
+    auto work_order = YAML::Load(raw).as<WorkOrder>();
+  }
+  catch (const std::invalid_argument& e)
+  {
+    invalid_argument = true;
+  }
+  CHECK(invalid_argument);
+}
+
+TEST_CASE("WorkOrder serialization with empty steps", "[Model][Serialization]")
+{
+  std::string raw{
+    R"RAW(
+      {
+        "workInstructionName": "CV-299 (Rev 4)",
+        "steps": []
+      }
+  )RAW"};
+
+  bool invalid_argument = false;
+  try
+  {
+    auto work_order = YAML::Load(raw).as<WorkOrder>();
+  }
+  catch (const std::invalid_argument& e)
+  {
+    invalid_argument = true;
+  }
+  CHECK(invalid_argument);
 }
 
 }  // namespace nexus::common::test

--- a/nexus_common/src/models/work_order_test.cpp
+++ b/nexus_common/src/models/work_order_test.cpp
@@ -44,13 +44,57 @@ TEST_CASE("WorkOrder serialization with metadata and process params",
             "processParams": {
               "param1": 10,
               "param2": "base_link"
-            }
+            },
+            "inputItems": [
+              {
+                "guid": "1001",
+                "metadata": {
+                  "description": "dummy_sku",
+                  "unit": "dummy_unit",
+                  "quantity": 1,
+                  "quantityPerPallet": 1
+                }
+              }
+            ]
           },
           {
-            "processId": "place"
+            "processId": "place",
+            "outputItems": [
+              {
+                "guid": "1001",
+                "metadata": {
+                  "description": "dummy_sku",
+                  "unit": "dummy_unit",
+                  "quantity": 1,
+                  "quantityPerPallet": 1
+                }
+              }
+            ]
           },
           {
-            "processId": "inspect"
+            "processId": "inspect",
+            "inputItems": [
+              {
+                "guid": "1001",
+                "metadata": {
+                  "description": "dummy_sku",
+                  "unit": "dummy_unit",
+                  "quantity": 1,
+                  "quantityPerPallet": 1
+                }
+              }
+            ],
+            "outputItems": [
+              {
+                "guid": "1001",
+                "metadata": {
+                  "description": "dummy_sku",
+                  "unit": "dummy_unit",
+                  "quantity": 1,
+                  "quantityPerPallet": 1
+                }
+              }
+            ]
           }
         ]
       }
@@ -77,14 +121,60 @@ TEST_CASE("WorkOrder serialization with metadata and process params",
     REQUIRE(step1_params);
     CHECK(step1_params["param1"].as<int>() == 10);
     CHECK(step1_params["param2"].as<std::string>() == "base_link");
+    const auto& step1_inputs = step1.input_items();
+    REQUIRE(step1_inputs.size() == 1);
+    auto item = step1_inputs[0];
+    CHECK(item.guid() == "1001");
+    REQUIRE(item.metadata().has_value());
+    const auto input_1_metadata = item.metadata().value();
+    CHECK(input_1_metadata.yaml["description"].as<std::string>() ==
+      "dummy_sku");
+    CHECK(input_1_metadata.yaml["unit"].as<std::string>() == "dummy_unit");
+    CHECK(input_1_metadata.yaml["quantity"].as<int>() == 1);
+    CHECK(input_1_metadata.yaml["quantityPerPallet"].as<int>() == 1);
+    CHECK(step1.output_items().size() == 0);
 
     const auto& step2 = steps[1];
     CHECK(step2.process_id() == "place");
     CHECK_FALSE(step2.process_params());
+    CHECK(step2.input_items().size() == 0);
+    const auto& step2_outputs = step2.output_items();
+    REQUIRE(step2_outputs.size() == 1);
+    item = step2_outputs[0];
+    CHECK(item.guid() == "1001");
+    REQUIRE(item.metadata().has_value());
+    const auto output_2_metadata = item.metadata().value();
+    CHECK(output_2_metadata.yaml["description"].as<std::string>() ==
+      "dummy_sku");
+    CHECK(output_2_metadata.yaml["unit"].as<std::string>() == "dummy_unit");
+    CHECK(output_2_metadata.yaml["quantity"].as<int>() == 1);
+    CHECK(output_2_metadata.yaml["quantityPerPallet"].as<int>() == 1);
 
     const auto& step3 = steps[2];
     CHECK(step3.process_id() == "inspect");
     CHECK_FALSE(step3.process_params());
+    const auto& step3_inputs = step3.input_items();
+    REQUIRE(step3_inputs.size() == 1);
+    item = step3_inputs[0];
+    CHECK(item.guid() == "1001");
+    REQUIRE(item.metadata().has_value());
+    const auto input_3_metadata = item.metadata().value();
+    CHECK(input_3_metadata.yaml["description"].as<std::string>() ==
+      "dummy_sku");
+    CHECK(input_3_metadata.yaml["unit"].as<std::string>() == "dummy_unit");
+    CHECK(input_3_metadata.yaml["quantity"].as<int>() == 1);
+    CHECK(input_3_metadata.yaml["quantityPerPallet"].as<int>() == 1);
+    const auto& step3_outputs = step3.output_items();
+    REQUIRE(step3_outputs.size() == 1);
+    item = step3_outputs[0];
+    CHECK(item.guid() == "1001");
+    REQUIRE(item.metadata().has_value());
+    const auto output_3_metadata = item.metadata().value();
+    CHECK(output_3_metadata.yaml["description"].as<std::string>() ==
+      "dummy_sku");
+    CHECK(output_3_metadata.yaml["unit"].as<std::string>() == "dummy_unit");
+    CHECK(output_3_metadata.yaml["quantity"].as<int>() == 1);
+    CHECK(output_3_metadata.yaml["quantityPerPallet"].as<int>() == 1);
   };
 
   auto work_order = YAML::Load(raw).as<WorkOrder>();

--- a/nexus_common/src/models/work_order_test.cpp
+++ b/nexus_common/src/models/work_order_test.cpp
@@ -15,9 +15,8 @@
  *
  */
 
+#include <nexus_common/models/work_order.hpp>
 #include <rmf_utils/catch.hpp>
-
-#include "models/work_order.hpp"
 
 #include <yaml-cpp/yaml.h>
 
@@ -103,13 +102,6 @@ TEST_CASE("WorkOrder serialization without metadata", "[Model][Serialization]")
     R"RAW(
       {
         "workInstructionName": "CV-299 (Rev 4)",
-        "item": {
-          "SkuId": "1001",
-          "description": "dummy_sku",
-          "unit": "dummy_unit",
-          "quantity": 1.0,
-          "quantityPerPallet": 1.0
-        },
         "steps": [
           {
             "processId": "pickup"
@@ -131,7 +123,7 @@ TEST_CASE("WorkOrder serialization without metadata", "[Model][Serialization]")
       REQUIRE_FALSE(maybe_metadata.has_value());
       REQUIRE(work_order.steps().size() == 3);
 
-      const auto steps = work_order.steps();
+    const auto steps = work_order.steps();
 
       const auto step1 = steps[0];
       CHECK(step1.process_id() == "pickup");
@@ -152,4 +144,4 @@ TEST_CASE("WorkOrder serialization without metadata", "[Model][Serialization]")
   check_data(work_order);
 }
 
-}
+} // namespace nexus::common::test

--- a/nexus_common/src/models/work_order_test.cpp
+++ b/nexus_common/src/models/work_order_test.cpp
@@ -234,4 +234,4 @@ TEST_CASE("WorkOrder serialization without metadata", "[Model][Serialization]")
   check_data(work_order);
 }
 
-} // namespace nexus::common::test
+}  // namespace nexus::common::test

--- a/nexus_common/src/node_utils.cpp
+++ b/nexus_common/src/node_utils.cpp
@@ -102,7 +102,8 @@ get_node_options_default(bool allow_undeclared, bool declare_initial_params)
 {
   rclcpp::NodeOptions options;
   options.allow_undeclared_parameters(allow_undeclared);
-  options.automatically_declare_parameters_from_overrides(declare_initial_params);
+  options.automatically_declare_parameters_from_overrides(
+    declare_initial_params);
   return options;
 }
 

--- a/nexus_demos/CMakeLists.txt
+++ b/nexus_demos/CMakeLists.txt
@@ -163,17 +163,15 @@ if(BUILD_TESTING)
     find_package(ament_index_cpp REQUIRED)
     find_package(rcpputils REQUIRED)
 
-    # To run the test use:
-    # ros2 run nexus_demos test_mocks
-    add_executable(test_mocks
+    ament_add_catch2(test_mocks
       test/main.cpp
-      src/mock_detector.cpp
-      src/mock_gripper.cpp
       src/test_mock_detector.cpp
       src/test_mock_gripper.cpp
     )
     target_link_libraries(test_mocks
       ament_index_cpp::ament_index_cpp
+      mock_detector_component
+      mock_gripper_component
       nexus_endpoints::nexus_endpoints
       rclcpp::rclcpp
       rclcpp_action::rclcpp_action
@@ -187,7 +185,6 @@ if(BUILD_TESTING)
     target_include_directories(test_mocks PUBLIC
       ${tf2_ros_INCLUDE_DIRS}
     )
-    install(TARGETS test_mocks RUNTIME DESTINATION lib/${PROJECT_NAME})
   endif()
 endif()
 

--- a/nexus_demos/config/pick_and_place.json
+++ b/nexus_demos/config/pick_and_place.json
@@ -9,10 +9,28 @@
   },
   "steps": [
     {
-      "processId": "place_on_conveyor"
+      "processId": "place_on_conveyor",
+      "outputs": [
+        {
+          "SkuId": "productA",
+          "description": "productA",
+          "unit": "dummy_unit",
+          "quantity": 1.0,
+          "quantityPerPallet": 1.0
+        }
+      ]
     },
     {
-      "processId": "pick_from_conveyor"
+      "processId": "pick_from_conveyor",
+      "inputs": [
+        {
+          "SkuId": "productA",
+          "description": "productA",
+          "unit": "dummy_unit",
+          "quantity": 1.0,
+          "quantityPerPallet": 1.0
+        }
+      ]
     }
   ]
 }

--- a/nexus_demos/config/pick_and_place.json
+++ b/nexus_demos/config/pick_and_place.json
@@ -1,34 +1,31 @@
 {
   "workInstructionName": "Pick and Place",
-  "metadata": {
-    "SkuId": "productA",
-    "description": "productA",
-    "unit": "dummy_unit",
-    "quantity": 1.0,
-    "quantityPerPallet": 1.0
-  },
   "steps": [
     {
       "processId": "place_on_conveyor",
-      "outputs": [
+      "outputItems": [
         {
-          "SkuId": "productA",
-          "description": "productA",
-          "unit": "dummy_unit",
-          "quantity": 1.0,
-          "quantityPerPallet": 1.0
+          "guid": "productA",
+          "metadata": {
+            "description": "productA",
+            "unit": "dummy_unit",
+            "quantity": 1.0,
+            "quantityPerPallet": 1.0
+          }
         }
       ]
     },
     {
       "processId": "pick_from_conveyor",
-      "inputs": [
+      "inputItems": [
         {
-          "SkuId": "productA",
-          "description": "productA",
-          "unit": "dummy_unit",
-          "quantity": 1.0,
-          "quantityPerPallet": 1.0
+          "guid": "productA",
+          "metadata": {
+            "description": "productA",
+            "unit": "dummy_unit",
+            "quantity": 1.0,
+            "quantityPerPallet": 1.0
+          }
         }
       ]
     }

--- a/nexus_demos/config/pick_and_place.json
+++ b/nexus_demos/config/pick_and_place.json
@@ -7,10 +7,8 @@
         {
           "guid": "productA",
           "metadata": {
-            "description": "productA",
-            "unit": "dummy_unit",
-            "quantity": 1.0,
-            "quantityPerPallet": 1.0
+            "quantity": 1,
+            "state": "state_1"
           }
         }
       ]
@@ -21,10 +19,8 @@
         {
           "guid": "productA",
           "metadata": {
-            "description": "productA",
-            "unit": "dummy_unit",
-            "quantity": 1.0,
-            "quantityPerPallet": 1.0
+            "quantity": 1,
+            "state": "state_1"
           }
         }
       ]

--- a/nexus_demos/config/pick_from_conveyor.json
+++ b/nexus_demos/config/pick_from_conveyor.json
@@ -1,22 +1,17 @@
 {
   "workInstructionName": "Pick from conveyor",
-  "metadata": {
-    "SkuId": "productA",
-    "description": "productA",
-    "unit": "dummy_unit",
-    "quantity": 1.0,
-    "quantityPerPallet": 1.0
-  },
   "steps": [
     {
       "processId": "pick_from_conveyor",
-      "inputs": [
+      "inputItems": [
         {
-          "SkuId": "productA",
-          "description": "productA",
-          "unit": "dummy_unit",
-          "quantity": 1.0,
-          "quantityPerPallet": 1.0
+          "guid": "productA",
+          "metadata": {
+            "description": "productA",
+            "unit": "dummy_unit",
+            "quantity": 1.0,
+            "quantityPerPallet": 1.0
+          }
         }
       ]
     }

--- a/nexus_demos/config/pick_from_conveyor.json
+++ b/nexus_demos/config/pick_from_conveyor.json
@@ -7,10 +7,8 @@
         {
           "guid": "productA",
           "metadata": {
-            "description": "productA",
-            "unit": "dummy_unit",
-            "quantity": 1.0,
-            "quantityPerPallet": 1.0
+            "quantity": 1,
+            "state": "state_1"
           }
         }
       ]

--- a/nexus_demos/config/pick_from_conveyor.json
+++ b/nexus_demos/config/pick_from_conveyor.json
@@ -9,7 +9,16 @@
   },
   "steps": [
     {
-      "processId": "pick_from_conveyor"
+      "processId": "pick_from_conveyor",
+      "inputs": [
+        {
+          "SkuId": "productA",
+          "description": "productA",
+          "unit": "dummy_unit",
+          "quantity": 1.0,
+          "quantityPerPallet": 1.0
+        }
+      ]
     }
   ]
 }

--- a/nexus_demos/config/place_on_conveyor.json
+++ b/nexus_demos/config/place_on_conveyor.json
@@ -9,7 +9,16 @@
   },
   "steps": [
     {
-      "processId": "place_on_conveyor"
+      "processId": "place_on_conveyor",
+      "outputs": [
+        {
+          "SkuId": "productA",
+          "description": "productA",
+          "unit": "dummy_unit",
+          "quantity": 1.0,
+          "quantityPerPallet": 1.0
+        }
+      ]
     }
   ]
 }

--- a/nexus_demos/config/place_on_conveyor.json
+++ b/nexus_demos/config/place_on_conveyor.json
@@ -1,22 +1,17 @@
 {
   "workInstructionName": "Place on conveyor",
-  "metadata": {
-    "SkuId": "productA",
-    "description": "productA",
-    "unit": "dummy_unit",
-    "quantity": 1.0,
-    "quantityPerPallet": 1.0
-  },
   "steps": [
     {
       "processId": "place_on_conveyor",
-      "outputs": [
+      "outputItems": [
         {
-          "SkuId": "productA",
-          "description": "productA",
-          "unit": "dummy_unit",
-          "quantity": 1.0,
-          "quantityPerPallet": 1.0
+          "guid": "productA",
+          "metadata": {
+            "description": "productA",
+            "unit": "dummy_unit",
+            "quantity": 1.0,
+            "quantityPerPallet": 1.0
+          }
         }
       ]
     }

--- a/nexus_demos/config/place_on_conveyor.json
+++ b/nexus_demos/config/place_on_conveyor.json
@@ -7,10 +7,8 @@
         {
           "guid": "productA",
           "metadata": {
-            "description": "productA",
-            "unit": "dummy_unit",
-            "quantity": 1.0,
-            "quantityPerPallet": 1.0
+            "quantity": 1,
+            "state": "state_1"
           }
         }
       ]

--- a/nexus_motion_planner/package.xml
+++ b/nexus_motion_planner/package.xml
@@ -33,6 +33,7 @@
   <test_depend>ament_cmake_uncrustify</test_depend>
   <test_depend>launch_pytest</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
+  <test_depend>rmw_cyclonedds_cpp</test_depend>
 
   <test_depend>moveit_configs_utils</test_depend>
   <test_depend>moveit_resources</test_depend>

--- a/nexus_system_orchestrator/src/system_orchestrator.cpp
+++ b/nexus_system_orchestrator/src/system_orchestrator.cpp
@@ -725,7 +725,7 @@ _parse_wo(const std::string& work_order_id, const common::WorkOrder& work_order)
       work_order.metadata().has_value() ? work_order.metadata().value() :
       YAML::Node{};
     YAML::Emitter out;
-    out << processed_step;
+    out << step.yaml;
     task.payload = out.c_str();
 
     tasks.emplace_back(task);

--- a/nexus_system_orchestrator/src/system_orchestrator.cpp
+++ b/nexus_system_orchestrator/src/system_orchestrator.cpp
@@ -725,7 +725,7 @@ _parse_wo(const std::string& work_order_id, const common::WorkOrder& work_order)
       work_order.metadata().has_value() ? work_order.metadata().value() :
       YAML::Node{};
     YAML::Emitter out;
-    out << step.yaml;
+    out << processed_step;
     task.payload = out.c_str();
 
     tasks.emplace_back(task);

--- a/nexus_transporter/test/test_Itinerary.cpp
+++ b/nexus_transporter/test/test_Itinerary.cpp
@@ -50,7 +50,7 @@ SCENARIO("Test Itinerary")
   CHECK(itinerary.id() == id);
   const auto & destinations_ = itinerary.destinations();
   CHECK(destinations_.size() == 1);
-  CHECK(destinations_[0].name == "pallet_1");
+  CHECK(destinations_[0].name == "workcell_1");
   CHECK(destinations_[0].action == Destination::ACTION_PICKUP);
   CHECK(destinations_[0].params == "");
   CHECK(itinerary.transporter_name() == transporter_name);
@@ -75,8 +75,8 @@ SCENARIO("Test Itinerary")
     itinerary.destinations(std::move(new_destinations));
     const auto & new_destinations_ = itinerary.destinations();
     CHECK(new_destinations_.size() == 1);
-    CHECK(new_destinations_[0].name == "pallet_1");
-    CHECK(new_destinations_[0].action == Destination::ACTION_PICKUP);
+    CHECK(new_destinations_[0].name == "workcell_2");
+    CHECK(new_destinations_[0].action == Destination::ACTION_DROPOFF);
     CHECK(new_destinations_[0].params == "");
   }
   WHEN("Setting new transporter_name")


### PR DESCRIPTION
This is will be one of the key concepts needed to set individual transportation steps for each work order step. 

* added `Item`, which has a guid and metadata, added test
* added input and output items for steps (this will be used to inform dispensers/ingesters
* tidied up CI, added separate unit test workflow (that won't build bridges)

In the future, when work orders need to be generated, the inputs and outputs can also help inform pre and post conditions of each step.  

I did some linting fixes too, but only on the packages that I touched with this PR. Will set up proper linting in a subsequent PR for the entire project.