### PR TITLE
Update default  WorkOrder model

### DIFF
--- a/nexus_common/include/nexus_common/models/metadata.hpp
+++ b/nexus_common/include/nexus_common/models/metadata.hpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2025 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef NEXUS_COMMON__MODELS__METADATA_HPP
+#define NEXUS_COMMON__MODELS__METADATA_HPP
+
+#include <optional>
+
+#include "../yaml_helpers.hpp"
+
+namespace nexus::common {
+
+class MetaData
+{
+public:
+  YAML::Node yaml;
+
+  MetaData(YAML::Node yaml)
+  : yaml(std::move(yaml)) {}
+
+  MetaData() {}
+};
+
+}  // namespace nexus::common
+
+namespace YAML {
+
+template<>
+struct convert<nexus::common::MetaData>
+{
+  static Node encode(const nexus::common::MetaData& data)
+  {
+    return data.yaml;
+  }
+
+  static bool decode(const Node& node, nexus::common::MetaData& data)
+  {
+    data.yaml = node;
+    return true;
+  }
+};
+
+}  // namespace YAML
+
+#endif  // NEXUS_COMMON__MODELS__METADATA_HPP

--- a/nexus_common/include/nexus_common/models/work_order.hpp
+++ b/nexus_common/include/nexus_common/models/work_order.hpp
@@ -50,6 +50,11 @@ public: struct Step
       return this->yaml["processId"].as<std::string>();
     }
 
+    YAML::Node process_params() const
+    {
+      return this->yaml["processParams"];
+    }
+
   };
 
 public: YAML::Node yaml;

--- a/nexus_common/include/nexus_common/models/work_order.hpp
+++ b/nexus_common/include/nexus_common/models/work_order.hpp
@@ -20,22 +20,13 @@
 
 #include <optional>
 
+#include "metadata.hpp"
 #include "../yaml_helpers.hpp"
 
 namespace nexus::common {
 
 class WorkOrder
 {
-public: struct MetaData
-  {
-    YAML::Node yaml;
-
-    MetaData(YAML::Node yaml)
-    : yaml(std::move(yaml)) {}
-
-    MetaData() {}
-  };
-
 public: struct Step
   {
     YAML::Node yaml;
@@ -86,21 +77,6 @@ public: std::vector<Step> steps() const
 }
 
 namespace YAML {
-
-template<>
-struct convert<nexus::common::WorkOrder::MetaData>
-{
-  static Node encode(const nexus::common::WorkOrder::MetaData& data)
-  {
-    return data.yaml;
-  }
-
-  static bool decode(const Node& node, nexus::common::WorkOrder::MetaData& data)
-  {
-    data.yaml = node;
-    return true;
-  }
-};
 
 template<>
 struct convert<nexus::common::WorkOrder::Step>

--- a/nexus_common/include/nexus_common/models/work_order.hpp
+++ b/nexus_common/include/nexus_common/models/work_order.hpp
@@ -18,45 +18,22 @@
 #ifndef NEXUS_COMMON__MODELS__WORK_ORDER_HPP
 #define NEXUS_COMMON__MODELS__WORK_ORDER_HPP
 
+#include <optional>
+
 #include "../yaml_helpers.hpp"
 
 namespace nexus::common {
 
 class WorkOrder
 {
-public: struct Item
+public: struct MetaData
   {
     YAML::Node yaml;
 
-    Item(YAML::Node yaml)
+    MetaData(YAML::Node yaml)
     : yaml(std::move(yaml)) {}
 
-    Item() {}
-
-    std::string sku_id() const
-    {
-      return this->yaml["SkuId"].as<std::string>();
-    }
-
-    std::string description() const
-    {
-      return this->yaml["description"].as<std::string>();
-    }
-
-    std::string unit() const
-    {
-      return this->yaml["unit"].as<std::string>();
-    }
-
-    int32_t quantity() const
-    {
-      return this->yaml["quantity"].as<double>();
-    }
-
-    int32_t quantity_per_pallet() const
-    {
-      return this->yaml["quantityPerPallet"].as<double>();
-    }
+    MetaData() {}
   };
 
 public: struct Step
@@ -73,10 +50,6 @@ public: struct Step
       return this->yaml["processId"].as<std::string>();
     }
 
-    std::string name() const
-    {
-      return this->yaml["name"].as<std::string>();
-    }
   };
 
 public: YAML::Node yaml;
@@ -91,9 +64,12 @@ public: std::string work_instruction_name() const
     return this->yaml["workInstructionName"].as<std::string>();
   }
 
-public: Item item() const
+public: std::optional<MetaData> metadata() const
   {
-    return this->yaml["item"];
+    if (this->yaml["metadata"]) {
+      return this->yaml["metadata"];
+    };
+    return std::nullopt;
   }
 
 public: std::vector<Step> steps() const
@@ -107,14 +83,14 @@ public: std::vector<Step> steps() const
 namespace YAML {
 
 template<>
-struct convert<nexus::common::WorkOrder::Item>
+struct convert<nexus::common::WorkOrder::MetaData>
 {
-  static Node encode(const nexus::common::WorkOrder::Item& data)
+  static Node encode(const nexus::common::WorkOrder::MetaData& data)
   {
     return data.yaml;
   }
 
-  static bool decode(const Node& node, nexus::common::WorkOrder::Item& data)
+  static bool decode(const Node& node, nexus::common::WorkOrder::MetaData& data)
   {
     data.yaml = node;
     return true;

--- a/nexus_demos/config/pick_and_place.json
+++ b/nexus_demos/config/pick_and_place.json
@@ -1,6 +1,6 @@
 {
   "workInstructionName": "Pick and Place",
-  "item": {
+  "metadata": {
     "SkuId": "productA",
     "description": "productA",
     "unit": "dummy_unit",
@@ -9,12 +9,10 @@
   },
   "steps": [
     {
-      "processId": "place_on_conveyor",
-      "name": "Pick and Place"
+      "processId": "place_on_conveyor"
     },
     {
-      "processId": "pick_from_conveyor",
-      "name": "Pick and Place"
+      "processId": "pick_from_conveyor"
     }
   ]
 }

--- a/nexus_demos/config/pick_from_conveyor.json
+++ b/nexus_demos/config/pick_from_conveyor.json
@@ -1,6 +1,6 @@
 {
   "workInstructionName": "Pick from conveyor",
-  "item": {
+  "metadata": {
     "SkuId": "productA",
     "description": "productA",
     "unit": "dummy_unit",
@@ -9,8 +9,7 @@
   },
   "steps": [
     {
-      "processId": "pick_from_conveyor",
-      "name": "Pick and Place"
+      "processId": "pick_from_conveyor"
     }
   ]
 }

--- a/nexus_demos/config/place_on_conveyor.json
+++ b/nexus_demos/config/place_on_conveyor.json
@@ -1,6 +1,6 @@
 {
   "workInstructionName": "Place on conveyor",
-  "item": {
+  "metadata": {
     "SkuId": "productA",
     "description": "productA",
     "unit": "dummy_unit",
@@ -9,8 +9,7 @@
   },
   "steps": [
     {
-      "processId": "place_on_conveyor",
-      "name": "Pick and Place"
+      "processId": "place_on_conveyor"
     }
   ]
 }

--- a/nexus_system_orchestrator/src/system_orchestrator.cpp
+++ b/nexus_system_orchestrator/src/system_orchestrator.cpp
@@ -719,10 +719,11 @@ _parse_wo(const std::string& work_order_id, const common::WorkOrder& work_order)
       this->_generate_task_id(work_order_id, step.process_id(), step_index++);
     task.type = step.process_id();
 
-    // FIXME(koonpeng): data from arcstone is missing the work order item,
-    // workaround by injecting it in.
+    // Inject metadata into payload for workcell.
     YAML::Node processed_step = step.yaml;
-    processed_step["item"] = work_order.item();
+    processed_step["metadata"] =
+      work_order.metadata().has_value() ? work_order.metadata().value() :
+      YAML::Node{};
     YAML::Emitter out;
     out << processed_step;
     task.payload = out.c_str();


### PR DESCRIPTION
This PR
- Gets rid of `Item` as a required field in the work order. This is replaced by `MetaData` which is optional in the work order. Users can directly access the yaml contents.
- Gets rid of `name` inside `Step` as it was redundant.
- Adds a getter for `process_parameters` in `Step` to return a YAML node of parameters. Downstream skills should have access to these parameters via `Task.data ` in the [context during configuration](https://github.com/osrf/nexus/blob/eb61acfab2cf44235ff132507a803e968ae92f9b/nexus_capabilities/include/nexus_capabilities/capability.hpp#L59)