### PR TITLE
Cancel callbacks for BT nodes in nexus_common

### DIFF
--- a/nexus_common/include/nexus_common/action_client_bt_node.hpp
+++ b/nexus_common/include/nexus_common/action_client_bt_node.hpp
@@ -68,6 +68,12 @@ protected: NodePtrT _node;
 protected: virtual std::string get_action_name() const = 0;
 
   /**
+   * A user overridable callback that will be triggered when the BT node is halted.
+   * The default implementation is a no-op.
+   */
+protected: void cancel_cb();
+
+  /**
    * Returns the goal to send to the server.
    */
 protected: virtual std::optional<typename ActionT::Goal> make_goal() = 0;
@@ -211,8 +217,18 @@ BT::NodeStatus ActionClientBtNode<NodePtrT, ActionT>::onRunning()
 }
 
 template<typename NodePtrT, typename ActionT>
+void ActionClientBtNode<NodePtrT, ActionT>::cancel_cb()
+{
+  // Default no-op
+  return;
+}
+
+template<typename NodePtrT, typename ActionT>
 void ActionClientBtNode<NodePtrT, ActionT>::onHalted()
 {
+  // First execute the cancel_cb.
+  this->cancel_cb();
+
   if (this->_goal_handle)
   {
     RCLCPP_INFO(this->_node->get_logger(), "%s: Cancelling goal",

--- a/nexus_common/include/nexus_common/service_client_bt_node.hpp
+++ b/nexus_common/include/nexus_common/service_client_bt_node.hpp
@@ -59,6 +59,12 @@ public: BT::NodeStatus onRunning() override;
 
 public: void onHalted() override;
 
+  /**
+   * A user overridable callback that will be triggered when the BT node is halted.
+   * The default implementation is a no-op.
+   */
+protected: void cancel_cb();
+
 protected: rclcpp::Logger _logger;
 
 /**
@@ -168,8 +174,18 @@ BT::NodeStatus ServiceClientBtNode<ServiceType>::onRunning()
 }
 
 template<typename ServiceType>
+void ServiceClientBtNode<ServiceType>::cancel_cb()
+{
+  // Default no-op
+  return;
+}
+
+template<typename ServiceType>
 void ServiceClientBtNode<ServiceType>::onHalted()
 {
+  // First execute the cancel_cb.
+  this->cancel_cb();
+
   RCLCPP_INFO(this->_logger, "%s: Halting", this->name().c_str());
   this->_cleanup();
 }


### PR DESCRIPTION
A minor improvement to allow users to override a cancellation callback that will be called when a BT node in `nexus_common` is halted. 