### PR TITLE
Add rmf_task_canceller node

### DIFF
--- a/nexus_capabilities/src/capabilities/rmf_request.cpp
+++ b/nexus_capabilities/src/capabilities/rmf_request.cpp
@@ -119,6 +119,13 @@ void DispatchRequest::api_response_cb(const ApiResponse& msg)
   if (!j.contains("state"))
     return;
   this->rmf_task_id = j["state"]["booking"]["id"];
+  // Also update the task_id with rmf_task_id to help with cancellation.
+  // The task_id before this is the work_order_id which is not ideal but
+  // the only option given we inject the RMF Workcell Task into the SO's assignments.
+  // See https://github.com/osrf/nexus/blob/702d76f70d0feeaf8f829fc2b8be1831a65a4b2c/nexus_system_orchestrator/src/assign_transporter_workcell.cpp#L70
+  auto context = _ctx_mgr->current_context();
+  context->task.task_id = *this->rmf_task_id;
+
 }
 
 BT::NodeStatus DispatchRequest::onRunning()

--- a/nexus_capabilities/src/capabilities/rmf_request.hpp
+++ b/nexus_capabilities/src/capabilities/rmf_request.hpp
@@ -68,8 +68,9 @@ public: static BT::PortsList providedPorts()
 
 public: DispatchRequest(const std::string& name,
     const BT::NodeConfiguration& config,
+    std::shared_ptr<const ContextManager> ctx_mgr,
     rclcpp_lifecycle::LifecycleNode::SharedPtr node)
-  : BT::StatefulActionNode(name, config), _node(std::move(node)) {}
+  : BT::StatefulActionNode(name, config), _node(std::move(node)), _ctx_mgr(ctx_mgr) {}
 
 public: BT::NodeStatus onStart() override;
 
@@ -82,6 +83,7 @@ private: void submit_itinerary(const std::deque<Destination>& destinations);
 private: void api_response_cb(const ApiResponse& msg);
 
 private: rclcpp_lifecycle::LifecycleNode::SharedPtr _node;
+private: std::shared_ptr<const ContextManager> _ctx_mgr;
 
 private: rclcpp::Publisher<ApiRequest>::SharedPtr _api_request_pub;
 private: rclcpp::Subscription<ApiResponse>::SharedPtr _api_response_sub;

--- a/nexus_capabilities/src/capabilities/rmf_request_capability.cpp
+++ b/nexus_capabilities/src/capabilities/rmf_request_capability.cpp
@@ -30,10 +30,10 @@ void RMFRequestCapability::configure(
   BT::BehaviorTreeFactory& bt_factory)
 {
   bt_factory.registerBuilder<DispatchRequest>("rmf_request.DispatchRequest",
-    [this, node](const std::string& name,
+    [this, node, ctx_mgr](const std::string& name,
     const BT::NodeConfiguration& config)
     {
-      return std::make_unique<DispatchRequest>(name, config, node);
+      return std::make_unique<DispatchRequest>(name, config, ctx_mgr, node);
     });
 
   bt_factory.registerBuilder<ExtractDestinations>("rmf_request.ExtractDestinations",

--- a/nexus_demos/CMakeLists.txt
+++ b/nexus_demos/CMakeLists.txt
@@ -5,7 +5,9 @@ project(${PROJECT_NAME} VERSION 0.0.1)
 find_package(ament_cmake REQUIRED)
 find_package(backward_ros REQUIRED)
 find_package(nexus_endpoints REQUIRED)
+find_package(nexus_orchestrator_msgs REQUIRED)
 find_package(nexus_transporter REQUIRED)
+find_package(nlohmann_json REQUIRED)
 find_package(yaml_cpp_vendor REQUIRED)
 find_package(yaml-cpp REQUIRED)
 find_package(pluginlib REQUIRED)
@@ -13,6 +15,8 @@ find_package(rclcpp REQUIRED)
 find_package(rclcpp_action REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
+find_package(rmf_dispenser_msgs REQUIRED)
+find_package(rmf_task_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(tf2_ros REQUIRED)
 
@@ -119,6 +123,30 @@ install(
   TARGETS
     mock_printer
     EXPORT export_${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+###############################################################################
+
+add_library(rmf_task_canceller_component SHARED src/rmf_task_canceller.cpp)
+target_link_libraries(rmf_task_canceller_component PRIVATE
+  rclcpp::rclcpp
+  rclcpp_components::component
+  nlohmann_json::nlohmann_json
+  ${nexus_orchestrator_msgs_TARGETS}
+  ${rmf_dispenser_msgs_TARGETS}
+  ${rmf_task_msgs_TARGETS}
+)
+target_compile_features(rmf_task_canceller_component INTERFACE cxx_std_17)
+rclcpp_components_register_node(rmf_task_canceller_component
+  PLUGIN "nexus_demos::RMFTaskCanceller"
+  EXECUTABLE rmf_task_canceller
+  EXECUTOR SingleThreadedExecutor)
+install(
+  TARGETS rmf_task_canceller_component
+  EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin

--- a/nexus_demos/launch/rmf_transporter.launch.xml
+++ b/nexus_demos/launch/rmf_transporter.launch.xml
@@ -72,6 +72,11 @@
     <param name="max_jobs" value="10"/>
   </node>
 
+  <!-- Temporary node to cancel RMF tasks if a workcell task fail -->
+  <node pkg="nexus_demos" exec="rmf_task_canceller" name="rmf_task_canceller" output="both">
+    <param name="rmf_workcell_name" value="rmf_nexus_transporter"/>
+  </node>
+
   <!-- Simulator launch -->
   <let name="gz_headless" if="$(var headless)" value="-s"/>
   <let name="gz_headless" unless="$(var headless)" value="" />

--- a/nexus_demos/package.xml
+++ b/nexus_demos/package.xml
@@ -16,13 +16,17 @@
   <depend>backward_ros</depend>
   <depend>lifecycle_msgs</depend>
   <depend>pluginlib</depend>
+  <depend>nexus_orchestrator_msgs</depend>
   <depend>nexus_transporter</depend>
+  <depend>nlohmann-json-dev</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_action</depend>
   <depend>rclcpp_components</depend>
   <depend>rclcpp_lifecycle</depend>
   <depend>rclpy</depend>
+  <depend>rmf_dispenser_msgs</depend>
   <depend>rmf_fleet_msgs</depend>
+  <depend>rmf_task_msgs</depend>
   <depend>std_srvs</depend>
   <depend>tf2_ros</depend>
   <depend>yaml-cpp</depend>

--- a/nexus_demos/src/rmf_task_canceller.cpp
+++ b/nexus_demos/src/rmf_task_canceller.cpp
@@ -1,0 +1,126 @@
+// Copyright 2025 Open Source Robotics Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rmf_task_canceller.hpp"
+
+#include <nexus_orchestrator_msgs/msg/task_state.hpp>
+
+#include <nlohmann/json.hpp>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <rmf_dispenser_msgs/msg/dispenser_request.hpp>
+#include <rmf_dispenser_msgs/msg/dispenser_result.hpp>
+#include <rmf_task_msgs/msg/api_request.hpp>
+#include <rmf_task_msgs/msg/api_response.hpp>
+
+namespace nexus_demos {
+
+//==============================================================================
+RMFTaskCanceller::RMFTaskCanceller(const rclcpp::NodeOptions & options)
+: Node("rmf_workcell_task_canceller"),
+  rmf_workcell_state_(nullptr)
+{
+  RCLCPP_INFO(
+    this->get_logger(),
+    "Starting rmf_task_canceller..."
+  );
+
+  const std::string rmf_workcell_name =
+    this->declare_parameter("rmf_workcell_name", "rmf_nexus_transporter");
+  const auto reliable_qos =
+    rclcpp::SystemDefaultsQoS().keep_last(10).reliable();
+  const auto transient_qos =
+    rclcpp::SystemDefaultsQoS().transient_local().keep_last(10).reliable();
+
+  rmf_api_request_pub_ = this->create_publisher<RMFApiRequest>(
+    "/task_api_requests",
+    transient_qos
+  );
+
+  dispenser_result_pub_ = this->create_publisher<DispenserResult>(
+    "/dispenser_results",
+    reliable_qos
+  );
+
+  dispenser_request_sub_ = this->create_subscription<DispenserRequest>(
+    "/dispenser_requests",
+    reliable_qos,
+    [this](DispenserRequest::ConstSharedPtr msg)
+    {
+      if (rmf_workcell_state_ == nullptr)
+      {
+        return;
+      }
+
+      if (msg->request_guid != rmf_workcell_state_->task_id)
+      {
+        return;
+      }
+
+      auto wo_it = cancelled_wo_.find(rmf_workcell_state_->work_order_id);
+      if (wo_it == cancelled_wo_.end())
+      {
+        return;
+      }
+
+      DispenserResult dispenser_result_msg;
+      dispenser_result_msg.request_guid = msg->request_guid;
+      dispenser_result_msg.source_guid = msg->target_guid;
+      dispenser_result_msg.status = DispenserResult::FAILED;
+      dispenser_result_pub_->publish(std::move(dispenser_result_msg));
+
+      // Also cancel the RMF task.
+      nlohmann::json cancel_json;
+      cancel_json["type"] = "cancel_task_request";
+      cancel_json["task_id"] = msg->request_guid;
+      RMFApiRequest cancel_request;
+      // Time since epoch as a unique id.
+      auto now = std::chrono::steady_clock::now().time_since_epoch();
+      cancel_request.request_id = std::chrono::duration_cast<std::chrono::nanoseconds>(now).count();
+      cancel_request.json_msg = cancel_json.dump();
+      this->rmf_api_request_pub_->publish(std::move(cancel_request));
+    }
+  );
+
+  rmf_state_sub_ = this->create_subscription<WorkcellState>(
+    "/" + rmf_workcell_name + "/workcell_state",
+    reliable_qos,
+    [this](WorkcellState::ConstSharedPtr msg)
+    {
+      if (msg->work_order_id.empty())
+      {
+        return;
+      }
+      this->rmf_workcell_state_ = msg;
+    }
+  );
+
+  wo_state_sub_ = this->create_subscription<WorkOrderState>(
+    "/work_order_states",
+    reliable_qos,
+    [this](WorkOrderState::ConstSharedPtr msg)
+    {
+      if (msg->state == WorkOrderState::STATE_CANCELLED ||
+        msg->state == WorkOrderState::STATE_FAILED)
+      {
+        cancelled_wo_[msg->id] = msg;
+      }
+    }
+  );
+}
+}  // namespace nexus_demos
+
+#include <rclcpp_components/register_node_macro.hpp>
+RCLCPP_COMPONENTS_REGISTER_NODE(nexus_demos::RMFTaskCanceller)

--- a/nexus_demos/src/rmf_task_canceller.cpp
+++ b/nexus_demos/src/rmf_task_canceller.cpp
@@ -26,7 +26,6 @@
 #include <rmf_task_msgs/msg/api_response.hpp>
 
 namespace nexus_demos {
-
 //==============================================================================
 RMFTaskCanceller::RMFTaskCanceller(const rclcpp::NodeOptions & options)
 : Node("rmf_workcell_task_canceller"),

--- a/nexus_demos/src/rmf_task_canceller.hpp
+++ b/nexus_demos/src/rmf_task_canceller.hpp
@@ -52,8 +52,6 @@ private:
   // The state of the RMF workcell.
   WorkcellState::ConstSharedPtr rmf_workcell_state_;
 };
-
 }  // namespace nexus_demos
-
 
 #endif  // SRC__RMF_TASK_CANCELLER_HPP_

--- a/nexus_demos/src/rmf_task_canceller.hpp
+++ b/nexus_demos/src/rmf_task_canceller.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SRC__RMF_TASK_CANCELLER_HPP_
-#define SRC__RMF_TASK_CANCELLER_HPP_
+#ifndef NEXUS_DEMOS__SRC__RMF_TASK_CANCELLER_HPP
+#define NEXUS_DEMOS__SRC__RMF_TASK_CANCELLER_HPP
 
 #include <nexus_orchestrator_msgs/msg/workcell_state.hpp>
 #include <nexus_orchestrator_msgs/msg/work_order_state.hpp>
@@ -54,4 +54,4 @@ private:
 };
 }  // namespace nexus_demos
 
-#endif  // SRC__RMF_TASK_CANCELLER_HPP_
+#endif  // NEXUS_DEMOS__SRC__RMF_TASK_CANCELLER_HPP

--- a/nexus_demos/src/rmf_task_canceller.hpp
+++ b/nexus_demos/src/rmf_task_canceller.hpp
@@ -1,0 +1,59 @@
+// Copyright 2025 Open Source Robotics Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SRC__RMF_TASK_CANCELLER_HPP_
+#define SRC__RMF_TASK_CANCELLER_HPP_
+
+#include <nexus_orchestrator_msgs/msg/workcell_state.hpp>
+#include <nexus_orchestrator_msgs/msg/work_order_state.hpp>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <rmf_dispenser_msgs/msg/dispenser_request.hpp>
+#include <rmf_dispenser_msgs/msg/dispenser_result.hpp>
+#include <rmf_task_msgs/msg/api_request.hpp>
+#include <rmf_task_msgs/msg/api_response.hpp>
+
+#include <unordered_map>
+
+namespace nexus_demos {
+using RMFApiRequest = rmf_task_msgs::msg::ApiRequest;
+using DispenserRequest = rmf_dispenser_msgs::msg::DispenserRequest;
+using DispenserResult = rmf_dispenser_msgs::msg::DispenserResult;
+using WorkcellState = nexus_orchestrator_msgs::msg::WorkcellState;
+using WorkOrderState = nexus_orchestrator_msgs::msg::WorkOrderState;
+
+//==============================================================================
+class RMFTaskCanceller : public rclcpp::Node
+{
+public:
+  RMFTaskCanceller(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+
+private:
+  std::shared_ptr<rclcpp::Publisher<RMFApiRequest>> rmf_api_request_pub_;
+  std::shared_ptr<rclcpp::Publisher<DispenserResult>> dispenser_result_pub_;
+  std::shared_ptr<rclcpp::Subscription<DispenserRequest>> dispenser_request_sub_;
+  std::shared_ptr<rclcpp::Subscription<WorkcellState>> rmf_state_sub_;
+  std::shared_ptr<rclcpp::Subscription<WorkOrderState>> wo_state_sub_;
+
+  // Map the work_order_id to the WorkOrderState msg.
+  std::unordered_map<std::string, WorkOrderState::ConstSharedPtr> cancelled_wo_;
+  // The state of the RMF workcell.
+  WorkcellState::ConstSharedPtr rmf_workcell_state_;
+};
+
+}  // namespace nexus_demos
+
+
+#endif  // SRC__RMF_TASK_CANCELLER_HPP_


### PR DESCRIPTION
This PR adds a `rmf_task_canceller` node that properly cancels RMF tasks when a workcell's task fails or is aborted. It does this by subscribing to the `/work_order_states` and keeps track of those WorkOrders that were cancelled. It also subscribes to `/<rmf_transporter_name>/workcell_state` to track the current task being done by the RMF Transporter. If this task matches one that has been cancelled AND DispenserRequest messages for this task are also being published, the `rmf_task_canceller` node, publishes a FAILED `DispenseResult` message and cancels the RMF task via `/task_api_requests`.

To make this work without hardcoding anything in the `rmf_task_canceller`, I updated the `rmf_request.DispatchRequest` BT node to update the current tasks's `task_id` field to match the `rmf_task_id` received from submitting the original task to RMF. It's not a great approach but currently the value is set to the `work_order_id` which isn't great either. 