### PR TITLE
Do not overwrite task id in DispatchRequest

### DIFF
--- a/nexus_capabilities/src/capabilities/rmf_request.cpp
+++ b/nexus_capabilities/src/capabilities/rmf_request.cpp
@@ -119,13 +119,6 @@ void DispatchRequest::api_response_cb(const ApiResponse& msg)
   if (!j.contains("state"))
     return;
   this->rmf_task_id = j["state"]["booking"]["id"];
-  // Also update the task_id with rmf_task_id to help with cancellation.
-  // The task_id before this is the work_order_id which is not ideal but
-  // the only option given we inject the RMF Workcell Task into the SO's assignments.
-  // See https://github.com/osrf/nexus/blob/702d76f70d0feeaf8f829fc2b8be1831a65a4b2c/nexus_system_orchestrator/src/assign_transporter_workcell.cpp#L70
-  auto context = _ctx_mgr->current_context();
-  context->task.task_id = *this->rmf_task_id;
-
 }
 
 BT::NodeStatus DispatchRequest::onRunning()

--- a/nexus_capabilities/src/capabilities/rmf_request.hpp
+++ b/nexus_capabilities/src/capabilities/rmf_request.hpp
@@ -68,9 +68,8 @@ public: static BT::PortsList providedPorts()
 
 public: DispatchRequest(const std::string& name,
     const BT::NodeConfiguration& config,
-    std::shared_ptr<const ContextManager> ctx_mgr,
     rclcpp_lifecycle::LifecycleNode::SharedPtr node)
-  : BT::StatefulActionNode(name, config), _node(std::move(node)), _ctx_mgr(ctx_mgr) {}
+  : BT::StatefulActionNode(name, config), _node(std::move(node)) {}
 
 public: BT::NodeStatus onStart() override;
 
@@ -83,7 +82,6 @@ private: void submit_itinerary(const std::deque<Destination>& destinations);
 private: void api_response_cb(const ApiResponse& msg);
 
 private: rclcpp_lifecycle::LifecycleNode::SharedPtr _node;
-private: std::shared_ptr<const ContextManager> _ctx_mgr;
 
 private: rclcpp::Publisher<ApiRequest>::SharedPtr _api_request_pub;
 private: rclcpp::Subscription<ApiResponse>::SharedPtr _api_response_sub;

--- a/nexus_capabilities/src/capabilities/rmf_request_capability.cpp
+++ b/nexus_capabilities/src/capabilities/rmf_request_capability.cpp
@@ -30,10 +30,10 @@ void RMFRequestCapability::configure(
   BT::BehaviorTreeFactory& bt_factory)
 {
   bt_factory.registerBuilder<DispatchRequest>("rmf_request.DispatchRequest",
-    [this, node, ctx_mgr](const std::string& name,
+    [this, node](const std::string& name,
     const BT::NodeConfiguration& config)
     {
-      return std::make_unique<DispatchRequest>(name, config, ctx_mgr, node);
+      return std::make_unique<DispatchRequest>(name, config, node);
     });
 
   bt_factory.registerBuilder<ExtractDestinations>("rmf_request.ExtractDestinations",

--- a/nexus_demos/src/rmf_task_canceller.cpp
+++ b/nexus_demos/src/rmf_task_canceller.cpp
@@ -63,11 +63,7 @@ RMFTaskCanceller::RMFTaskCanceller(const rclcpp::NodeOptions & options)
         return;
       }
 
-      if (msg->request_guid != rmf_workcell_state_->task_id)
-      {
-        return;
-      }
-
+      // Check if the AMR is processing a cancelled work order.
       auto wo_it = cancelled_wo_.find(rmf_workcell_state_->work_order_id);
       if (wo_it == cancelled_wo_.end())
       {


### PR DESCRIPTION
This PR reverts the logic introduced in #94 where the `DispatchReqeust` skill overwrites the `task_id` for the workcell. 

Turns out overwriting the `task_id` in the workcell prevents it from receiving [signals](https://github.com/osrf/nexus/blob/main/nexus_system_orchestrator/src/send_signal.cpp#L47-L48) from the system orchestrator 😅 

I removed the  `if (msg->request_guid != rmf_workcell_state_->task_id)` check in the `rmf_task_canceller` node as this was just an extra safety check. I've tested functionality locally and things work as expected. 