### PR TITLE
Build basic RMF image, to be optionally used for CI

### DIFF
--- a/.github/rmf/Dockerfile
+++ b/.github/rmf/Dockerfile
@@ -1,5 +1,5 @@
 ARG ROS_DISTRO=jazzy
-ARG BASE_IMAGE=docker.io/ros:$ROS_DISTRO-ros-base
+ARG BASE_IMAGE=ros:$ROS_DISTRO-ros-base
 FROM $BASE_IMAGE
 ARG RMF_BRANCH=main
 
@@ -13,9 +13,10 @@ RUN rosdep update && rosdep install --from-paths /rmf/src -yi
 
 RUN cd /rmf \
   && . /opt/ros/$ROS_DISTRO/setup.sh \
-  && colcon build --merge-install --install-base /opt/ros/$ROS_DISTRO --cmake-args -DCMAKE_BUILD_TYPE=Release
+  && colcon build --mixin release
 
-RUN rm -rf /rmf /var/lib/apt/lists
+RUN rm -rf /var/lib/apt/lists /rmf/build /rmf/src /rmf/log \
+  && sed -i '$isource "/rmf/install/setup.bash"' /ros_entrypoint.sh
 
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["bash"]

--- a/.github/rmf/Dockerfile
+++ b/.github/rmf/Dockerfile
@@ -1,0 +1,21 @@
+ARG ROS_DISTRO=jazzy
+ARG BASE_IMAGE=docker.io/ros:$ROS_DISTRO-ros-base
+FROM $BASE_IMAGE
+ARG RMF_BRANCH=main
+
+RUN apt-get update && apt-get install -y wget ros-dev-tools
+
+RUN mkdir -p /rmf/src && cd /rmf \
+  && wget https://raw.githubusercontent.com/open-rmf/rmf/$RMF_BRANCH/rmf.repos \
+  && vcs import /rmf/src < /rmf/rmf.repos
+
+RUN rosdep update && rosdep install --from-paths /rmf/src -yi
+
+RUN cd /rmf \
+  && . /opt/ros/$ROS_DISTRO/setup.sh \
+  && colcon build --merge-install --install-base /opt/ros/$ROS_DISTRO --cmake-args -DCMAKE_BUILD_TYPE=Release
+
+RUN rm -rf /rmf /var/lib/apt/lists
+
+ENTRYPOINT ["/ros_entrypoint.sh"]
+CMD ["bash"]

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -1,0 +1,40 @@
+name: Build docker images
+
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      ros_distribution:
+        description: "ROS 2 distribution"
+        required: true
+        type: string
+        default: "jazzy"
+      rmf_branch:
+        description: "Branch of open-rmf/rmf repository"
+        required: true
+        type: string
+        default: "main"
+
+jobs:
+  build-rmf-image:
+    name: Push RMF Docker image to GitHub Packages
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to docker
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push rmf
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          build-args: |
+            ROS_DISTRO=${{ inputs.ros_distribution }}
+            RMF_BRANCH=${{ inputs.rmf_branch}}
+          tags: ghcr.io/${{ github.repository }}/rmf:${{ inputs.ros_distribution }}-rmf-${{ inputs.rmf_branch }}
+          context: .github/rmf

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -1,7 +1,6 @@
 name: Build docker images
 
 on:
-  pull_request:
   workflow_dispatch:
     inputs:
       ros_distribution:
@@ -34,7 +33,7 @@ jobs:
         with:
           push: true
           build-args: |
-            ROS_DISTRO=jazzy
-            RMF_BRANCH=main
-          tags: ghcr.io/${{ github.repository }}/rmf:jazzy-rmf-main
+            ROS_DISTRO=${{ inputs.ros_distribution }}
+            RMF_BRANCH=${{ inputs.rmf_branch }}
+          tags: ghcr.io/${{ github.repository }}/rmf:${{ inputs.ros_distribution }}-rmf-${{ inputs.rmf_branch }}
           context: .github/rmf

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -1,7 +1,6 @@
 name: Build docker images
 
 on:
-  pull_request:
   workflow_dispatch:
     inputs:
       ros_distribution:
@@ -34,7 +33,7 @@ jobs:
         with:
           push: true
           build-args: |
-            ROS_DISTRO=jazzy
-            RMF_BRANCH=main
-          tags: ghcr.io/${{ github.repository }}/rmf:jazzy-rmf-main
+            ROS_DISTRO=${{ inputs.ros_distribution }}
+            RMF_BRANCH=${{ inputs.rmf_branch}}
+          tags: ghcr.io/${{ github.repository }}/rmf:${{ inputs.ros_distribution }}-rmf-${{ inputs.rmf_branch }}
           context: .github/rmf

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -34,7 +34,7 @@ jobs:
         with:
           push: true
           build-args: |
-            ROS_DISTRO=${{ inputs.ros_distribution }}
-            RMF_BRANCH=${{ inputs.rmf_branch}}
-          tags: ghcr.io/${{ github.repository }}/rmf:${{ inputs.ros_distribution }}-rmf-${{ inputs.rmf_branch }}
+            ROS_DISTRO=jazzy
+            RMF_BRANCH=main
+          tags: ghcr.io/${{ github.repository }}/rmf:jazzy-rmf-main
           context: .github/rmf

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -1,6 +1,7 @@
 name: Build docker images
 
 on:
+  pull_request:
   workflow_dispatch:
     inputs:
       ros_distribution:
@@ -33,7 +34,7 @@ jobs:
         with:
           push: true
           build-args: |
-            ROS_DISTRO=${{ inputs.ros_distribution }}
-            RMF_BRANCH=${{ inputs.rmf_branch}}
-          tags: ghcr.io/${{ github.repository }}/rmf:${{ inputs.ros_distribution }}-rmf-${{ inputs.rmf_branch }}
+            ROS_DISTRO=jazzy
+            RMF_BRANCH=main
+          tags: ghcr.io/${{ github.repository }}/rmf:jazzy-rmf-main
           context: .github/rmf


### PR DESCRIPTION
With the ongoing development and integration of the RMF transporter #104 and #106 , we will need newer RMF features unreleased into jazzy. This workflow will allow us to manually trigger image builds that will have RMF source built