### PR TITLE
Don't queue a task if any task assignment failed

### DIFF
--- a/nexus_system_orchestrator/src/context.hpp
+++ b/nexus_system_orchestrator/src/context.hpp
@@ -139,13 +139,13 @@ private:
   std::unordered_map<std::string, std::string> _workcell_task_assignments = {};
 
   /**
-   * Map of workcell ids and it's session.
+   * Map of workcell ids and its session.
    */
   std::unordered_map<std::string,
   std::shared_ptr<WorkcellSession>> _workcell_sessions;
 
   /**
-   * Map of transporter ids and it's session.
+   * Map of transporter ids and its session.
    */
   std::unordered_map<std::string,
   std::shared_ptr<TransporterSession>> _transporter_sessions;

--- a/nexus_system_orchestrator/src/system_orchestrator.cpp
+++ b/nexus_system_orchestrator/src/system_orchestrator.cpp
@@ -637,6 +637,10 @@ void SystemOrchestrator::_init_job(
             this->_jobs.erase(work_order_id);
             return;
           }
+        }
+        for (const auto& [task_id, maybe_assignment] : maybe_task_assignments)
+        {
+          // Task assignments are valid, they have been checked in the previous loop
           job.ctx->set_workcell_task_assignment(task_id, *maybe_assignment);
           auto task_state = TaskState();
           task_state.workcell_id = *maybe_assignment;


### PR DESCRIPTION
The "easiest fix" to https://github.com/osrf/nexus/issues/108.

I believe at least part of the issue is that we iterate through the list, enqueue tasks, but stop and fail altogether as long as one element of the list is invalid.
The simplest solution is... Just make sure all the elements in the list are valid before proceeding to enqueue tasks.

We should still look into #102 but at least this solves this bug (that would also be present if we implemented #102)