### PR TITLE
Fixed typo in CMakeLists.txt causing build failure

### DIFF
--- a/nexus_robot_controller/CMakeLists.txt
+++ b/nexus_robot_controller/CMakeLists.txt
@@ -22,7 +22,7 @@ endforeach()
 
 # Library
 add_library(${library_name} src/robot_controller_server.cpp)
-target_link_libraries({${library_name} PUBLIC
+target_link_libraries(${library_name} PUBLIC
   controller_manager::controller_manager
   rclcpp::rclcpp
   rclcpp_lifecycle::rclcpp_lifecycle


### PR DESCRIPTION
Fixed bug causing https://github.com/osrf/nexus/issues/113#issue-3301828503

Tested:
1. Followed the README setup instructions through https://github.com/osrf/nexus?tab=readme-ov-file#build-the-nexus-workspace
2. Confirmed no failed packages from the step: 
```bash
colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release
```