### PR TITLE
Remove ccache from CI

### DIFF
--- a/.github/workflows/nexus_integration_tests.yaml
+++ b/.github/workflows/nexus_integration_tests.yaml
@@ -30,13 +30,12 @@ jobs:
     - name: rosdep
       run: |
         apt update
-        apt install -y ccache
         colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
         colcon mixin update default
         rosdep update
         rosdep install --from-paths . -yir
     - name: build
-      run: /ros_entrypoint.sh colcon build --packages-up-to nexus_calibration nexus_gazebo nexus_demos nexus_motion_planner --mixin release --cmake-args -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+      run: /ros_entrypoint.sh colcon build --packages-up-to nexus_calibration nexus_gazebo nexus_demos nexus_motion_planner --mixin release
     - name: Test - Unit Tests
       run: . ./install/setup.bash && RMW_IMPLEMENTATION=rmw_cyclonedds_cpp /ros_entrypoint.sh colcon test --packages-select nexus_motion_planner --event-handlers=console_direct+
     - name: Test - Integration test


### PR DESCRIPTION
Do you know why CI has been flaky for ages?

Because specifying `--cmake-args` after the mixin overwrote the `release` mixin and we were building in debug mode.

There.