### PR TITLE
Introduce a sorted set for workcell tasks

### DIFF
--- a/nexus_capabilities/include/nexus_capabilities/context.hpp
+++ b/nexus_capabilities/include/nexus_capabilities/context.hpp
@@ -53,11 +53,28 @@ public: Task task;
 public: std::vector<std::string> errors;
 public: std::unique_ptr<common::BtLogging> bt_logging;
 public: std::unordered_set<std::string> signals;
-public: TaskState task_state;
+private: uint8_t task_status;
 public: uint64_t tick_count = 0;
+// Used to keep track of the last time the state was changed
+public: rclcpp::Time state_transition_time;
 
 public: Context(rclcpp_lifecycle::LifecycleNode& node)
-  : node(node) {}
+  : node(node), state_transition_time(node.now()) {}
+
+public: void set_task_status(uint8_t status)
+{
+  this->task_status = status;
+  this->state_transition_time = node.now();
+}
+
+public: TaskState get_task_state() const
+{
+  TaskState task_state;
+  task_state.task_id = this->task.task_id;
+  task_state.workcell_id = this->node.get_name();
+  task_state.status = this->task_status;
+  return task_state;
+}
 };
 
 } // namespace nexus


### PR DESCRIPTION
Fixes https://github.com/osrf/nexus/issues/102

A simple implementation of an ordered data structure for tasks stored at the workcell orchestrator level (in the end a `set` rather than a `priority_queue` as proposed, I think priority queues don't allow reordering items at runtime).
Changing from a fixed FIFO to a random access (but still ordered) data structure, allows the system orchestrator to request task execution for previously queued tasks at any time, without being forced to use the same order tasks were enqueued. This should allow higher efficiency as well as preventing deadlocks when, for example, integrating with AMR systems.

If tasks have the same status, we compare the time that status was set (so for example, if a task_0 was set to `RUNNING` at t=100s and a task_1 was set to `RUNNING` at t=200s, task_0 will always be earlier in the queue.
If tasks have a different status, they will be ordered in order of `RUNNING` - `QUEUED` - `ASSIGNED` - others (`FAILED`, `FINISHED`, undefined values).

Note that what _really_ matters to make sure current behavior is preserved is that priority is respected when tasks are `RUNNING`, all the other states are not so important. Specifically, the current behavior is that tasks that are running do so in a "FIFO" basis, so the first item that is asked to run will do so and, if other tasks are requested to run but the workcell is not able to perform parallel tasks, they will not preempt the currently running task until it is finished.
This is ensured by the request time logic.

TODO:

- [ ] Refactor the custom set into a separate file, possibly in `context.hpp`.
- [ ] Add unit tests for the custom comparator.