### PR TITLE
Conveyor mode for mock transporter

### DIFF
--- a/nexus_demos/launch/inter_workcell.launch.py
+++ b/nexus_demos/launch/inter_workcell.launch.py
@@ -184,6 +184,7 @@ def launch_setup(context, *args, **kwargs):
             {"transporter_plugin": transporter_plugin},
             {"nav_graph_files": [os.path.join(get_package_share_directory("nexus_demos"), "config", "rmf", "maps", "depot", "nav_graphs", "1.yaml")]},
             {"travel_duration_seconds_per_destination": 2},
+            {"conveyor_mode": True},
         ],
         condition=UnlessCondition(use_rmf_transporter),
     )


### PR DESCRIPTION
Adding conveyor mode, which lets the mock transporter start from the first destination immediately

https://github.com/user-attachments/assets/84b4f4c5-3166-4a60-a724-d26bbf98fa43