### PR TITLE
Logging info and error messages coming from workcell orchestrators

### DIFF
--- a/nexus_msgs/nexus_orchestrator_msgs/msg/TaskState.msg
+++ b/nexus_msgs/nexus_orchestrator_msgs/msg/TaskState.msg
@@ -6,8 +6,10 @@ string task_id
 
 TaskProgress progress
 
-# [OPTIONAL] message for debugging 
-string message
+# [OPTIONAL] messages for debugging
+string[] messages
+
+string[] error_messages
 
 uint8 status
 uint8 STATUS_NONE = 0

--- a/nexus_system_orchestrator/src/system_orchestrator.cpp
+++ b/nexus_system_orchestrator/src/system_orchestrator.cpp
@@ -495,8 +495,23 @@ BT::Tree SystemOrchestrator::_create_bt(const WorkOrderActionType::Goal& wo,
     [this, ctx](const std::string& name, const BT::NodeConfiguration& config)
     {
       return std::make_unique<WorkcellRequest>(name, config, *this, ctx,
-      [this, ctx](const auto&)
+      [this, ctx](const auto& task_states)
       {
+        // handle feedback internally in system orchestrator
+        for (const auto& it : task_states)
+        {
+          for (const auto& m : it.second.messages)
+          {
+            RCLCPP_INFO(
+              this->get_logger(), "%s: %s", it.first.c_str(), m.c_str());
+          }
+          for (const auto& em: it.second.error_messages)
+          {
+            RCLCPP_ERROR(
+              this->get_logger(), "%s: %s", it.first.c_str(), em.c_str());
+          }
+        }
+
         this->_publish_wo_feedback(*ctx);
         try
         {

--- a/nexus_workcell_orchestrator/src/workcell_orchestrator.cpp
+++ b/nexus_workcell_orchestrator/src/workcell_orchestrator.cpp
@@ -475,6 +475,8 @@ auto WorkcellOrchestrator::_configure(
       auto fb = std::make_shared<WorkcellRequest::Feedback>();
       fb->state = ctx->task_state;
       goal_handle->publish_feedback(fb);
+      ctx->task_state.messages.clear();
+      ctx->task_state.error_messages.clear();
 
       if (it == this->_ctxs.end())
       {
@@ -803,6 +805,8 @@ void WorkcellOrchestrator::_tick_bt(const std::shared_ptr<Context>& ctx)
     auto fb = std::make_shared<WorkcellRequest::Feedback>();
     fb->state = ctx->task_state;
     goal_handle->publish_feedback(fb);
+    ctx->task_state.messages.clear();
+    ctx->task_state.error_messages.clear();
   }
 
   if (ctx->task_state.status == TaskState::STATUS_RUNNING)
@@ -1123,6 +1127,8 @@ void WorkcellOrchestrator::_handle_command_failed(
   auto fb = std::make_shared<WorkcellRequest::Feedback>();
   fb->state = ctx->task_state;
   ctx->goal_handle->publish_feedback(std::move(fb));
+  ctx->task_state.messages.clear();
+  ctx->task_state.error_messages.clear();
   // Abort the action request.
   auto result =
     std::make_shared<endpoints::WorkcellRequestAction::ActionType::Result>();


### PR DESCRIPTION
## What's new

* support multiple messages and error messages within `TaskState`
* system orchestrator to log messages arising from `WorkcellRequest`

### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [ ] I used a GenAI tool in this PR.
- [x] I did not use GenAI

Generated-by:
