### PR TITLE
Use released binaries for zenoh-bridge-ros2dds

### DIFF
--- a/nexus_demos/launch/zenoh_bridge.launch.py
+++ b/nexus_demos/launch/zenoh_bridge.launch.py
@@ -20,7 +20,6 @@ from launch.actions import (
 )
 from launch.conditions import IfCondition
 from launch.substitutions import (
-    FindExecutable,
     LaunchConfiguration,
     PathJoinSubstitution,
 )
@@ -40,7 +39,7 @@ def launch_setup(context, *args, **kwargs):
 
     cmd = [
         ExecutableInPackage(
-            executable="zenoh_bridge_ros2dds",
+            executable="zenoh-bridge-ros2dds",
             package="nexus_zenoh_bridge_dds_vendor",
         ),
         "--config",

--- a/nexus_zenoh_bridge_dds_vendor/CMakeLists.txt
+++ b/nexus_zenoh_bridge_dds_vendor/CMakeLists.txt
@@ -8,19 +8,26 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 find_package(ament_cmake REQUIRED)
-find_package(ament_cmake_vendor_package REQUIRED)
 
-ament_vendor(zeno_bridge_dds_vendor
-  VCS_URL https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds.git
-  VCS_VERSION 1.0.3
+set(ZENOH_VERSION "1.0.3")
+set(BINARY_URL "https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds/releases/download/${ZENOH_VERSION}/zenoh-plugin-ros2dds-${ZENOH_VERSION}-x86_64-unknown-linux-gnu-standalone.zip")
+set(BINARY_DIR "${CMAKE_BINARY_DIR}/download")
+file(DOWNLOAD ${BINARY_URL} ${BINARY_DIR}/zenoh-plugin-ros2dds.zip)
+
+find_program(UNZIP_EXECUTABLE unzip)
+if(NOT UNZIP_EXECUTABLE)
+  message(FATAL_ERROR "unzip command not found. Please install it.")
+endif()
+
+execute_process(
+  COMMAND ${UNZIP_EXECUTABLE} ${BINARY_DIR}/zenoh-plugin-ros2dds.zip
+  WORKING_DIRECTORY ${BINARY_DIR}
 )
 
-# TODO(sloretz) make a nice way to get this path from ament_vendor
-set(INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/zeno_bridge_dds_vendor-prefix/install")
 install(
-  DIRECTORY "${INSTALL_DIR}/lib/zenoh_bridge_ros2dds/"
+  FILES ${BINARY_DIR}/zenoh-bridge-ros2dds
   DESTINATION "lib/${PROJECT_NAME}"
-  USE_SOURCE_PERMISSIONS
+  PERMISSIONS OWNER_EXECUTE
 )
 
 ament_package()

--- a/nexus_zenoh_bridge_dds_vendor/CMakeLists.txt
+++ b/nexus_zenoh_bridge_dds_vendor/CMakeLists.txt
@@ -9,7 +9,7 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 
-set(ZENOH_VERSION "1.0.3")
+set(ZENOH_VERSION "1.7.1")
 set(BINARY_URL "https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds/releases/download/${ZENOH_VERSION}/zenoh-plugin-ros2dds-${ZENOH_VERSION}-x86_64-unknown-linux-gnu-standalone.zip")
 set(BINARY_DIR "${CMAKE_BINARY_DIR}/download")
 file(DOWNLOAD ${BINARY_URL} ${BINARY_DIR}/zenoh-plugin-ros2dds.zip)

--- a/nexus_zenoh_bridge_dds_vendor/package.xml
+++ b/nexus_zenoh_bridge_dds_vendor/package.xml
@@ -8,7 +8,6 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>ament_cmake_vendor_package</buildtool_depend>
 
   <build_depend>cargo</build_depend>
   <build_depend>clang</build_depend>


### PR DESCRIPTION
## What's new

* worked off https://github.com/osrf/nexus/pull/74
* use released binaries in vendor package
* update zenoh bridge version to latest

<!-- Describe your changes. -->

### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [ ] I used a GenAI tool in this PR.
- [x] I did not use GenAI

Generated-by:
